### PR TITLE
Revamp dashboard layout and analytics visuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ jspm_packages/
 
 # Gatsby files
 .cache/
-public
 
 # Storybook build outputs
 .out

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ A modern, responsive web application for analyzing used car listings with real-t
 
 - **📊 Real-time Data Analysis**: Live data from R2 storage with automatic updates
 - **🔍 Advanced Filtering**: Search by brand, model, location, body type, and more
-- **📈 Interactive Charts**: Price trends, brand analysis, and time-based insights
+- **📈 Interactive Charts**: Expanded dashboards covering price trends, mileage correlations, body-type mix, and market discounts
 - **🔎 Intelligent Search**: Multi-select search box with instant autocomplete across make, model, city, specs, and more
 - **📱 Responsive Design**: Optimized for desktop, tablet, and mobile devices
 - **⚡ Fast Performance**: Paginated tables with 20 items per page
 - **🎨 Modern UI/UX**: Bootstrap 5 with industry-standard design patterns
 - **🕒 Latest Listings Highlight**: Automatically highlights newest entries
 - **📍 Location Intelligence**: City-based filtering and analysis
-- **🔝 Sticky Header Search**: Compact top bar with always-on search, inline filters, and quick navigation
-- **🧮 Analytics Workspace**: Redesigned insights hub with summary metrics, top segments, and a custom KPI builder
+- **🧭 Adaptive Sidebar Workspace**: Minimal header paired with a persistent sidebar for search, filters, and quick navigation
+- **🧮 Analytics Workspace**: Redesigned insight builder supporting metrics, summary tables, and charts with per-widget filters
 
 ## 🚀 Quick Start
 
@@ -109,9 +109,12 @@ The application expects JSON data with the following structure:
 - **Quick Access**: Click any row to jump straight to the live listing (opens in new tab)
 
 ### Charts Page
-- **Price vs Year**: Scatter plot showing price distribution by year
-- **Brand Analysis**: Bar chart of average prices by car make
-- **Time Series**: Line chart showing price trends over time
+- **Price vs model year**: Scatter plot revealing depreciation patterns by manufacturer and city
+- **Price vs mileage**: Mileage-to-price correlation with tooltips for make and model year context
+- **Average price by make**: Horizontal ranking of the most premium brands filtered by active dataset
+- **Body type distribution**: Pie chart highlighting segment share across sedans, SUVs, hatchbacks, and more
+- **Market discount by make**: Horizontal bars surfacing where listings sit below market averages
+- **Price & volume over time**: Dual-axis view combining average price with daily listing volume
 
 ## 🏗️ Architecture
 
@@ -144,7 +147,7 @@ src/
 - **Responsive**: Mobile-first design approach
 
 ### Key Components
-- **Header**: Compact design with stats and navigation
+- **Sidebar**: Dedicated navigation, search, and filters with mobile toggle
 - **Table**: Sortable, paginated data table with hover effects
 - **Cards**: Clean card-based layout for filters and charts
 - **Forms**: Accessible form controls with proper labels
@@ -170,7 +173,7 @@ npm test
 ### Testing
 
 - **Unit tests** cover interactive primitives like the intelligent search multi-select.
-- **Integration tests** exercise end-to-end analytics workflows, including KPI filtering and insight tables.
+- **Integration tests** exercise end-to-end analytics workflows, including widget filters, grouped tables, and chart previews.
 - Execute the full suite with `npm test`. Use `npm run test:watch` during development for rapid feedback.
 
 ### Code Quality

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Used Cars Listings Dashboard</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="/src/styles.css" />
   </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#10b981" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#grad)" />
+  <path d="M17 34h30l4 12H13l4-12z" fill="#fff" opacity="0.9" />
+  <path d="M20 30l4-8h16l4 8" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.9" />
+  <circle cx="22" cy="48" r="5" fill="#fff" opacity="0.95" />
+  <circle cx="42" cy="48" r="5" fill="#fff" opacity="0.95" />
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { NavLink, Routes, Route } from "react-router-dom";
+import { NavLink, Routes, Route, useLocation } from "react-router-dom";
 import SearchMultiSelect from "./components/SearchMultiSelect.jsx";
 import Overview from "./pages/Overview.jsx";
 import Charts from "./pages/Charts.jsx";
@@ -148,6 +148,8 @@ export default function App() {
   const [dateFilter, setDateFilter] = useState("all");
   const [customWeeks, setCustomWeeks] = useState("4");
   const [resetSignal, setResetSignal] = useState(0);
+  const [isSidebarOpen, setSidebarOpen] = useState(false);
+  const location = useLocation();
 
   const cityOptions = useMemo(
     () => [...new Set(data.map((d) => d.city_inferred).filter(Boolean))].sort(),
@@ -157,6 +159,10 @@ export default function App() {
     () => [...new Set(data.map((d) => d.details_body_type).filter(Boolean))].sort(),
     [data]
   );
+
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [location.pathname]);
 
   const searchSuggestions = useMemo(() => {
     const map = new Map();
@@ -382,36 +388,87 @@ export default function App() {
   };
 
   return (
-    <div className="min-vh-100 bg-light">
-      {/* Header */}
+    <div className="app-root min-vh-100 bg-light">
       <header className="app-header shadow-sm border-bottom sticky-top" style={{ zIndex: 1030 }}>
-        <div className="container-fluid py-3">
-          <div className="app-header__grid">
-            <div className="app-header__brand">
-              <h1 className="h5 mb-1 text-primary fw-bold">🚗 Used Cars Dashboard</h1>
-              <p className="text-muted small mb-0">Real-time car listings analysis</p>
+        <div className="container-fluid py-3 d-flex align-items-center justify-content-between gap-3">
+          <div>
+            <h1 className="h5 mb-0 text-primary fw-bold">🚗 Used Cars Dashboard</h1>
+            <p className="text-muted extra-small mb-0">Real-time listings intelligence</p>
+          </div>
+          <div className="d-flex align-items-center gap-2">
+            <dl className="app-header__mini-stats d-none d-md-flex mb-0" aria-label="Snapshot of filtered dataset">
+              <div>
+                <dt className="text-muted extra-small text-uppercase">Listings</dt>
+                <dd className="mb-0 fw-semibold">{stats.totalListings.toLocaleString()}</dd>
+              </div>
+              <div>
+                <dt className="text-muted extra-small text-uppercase">Avg. price</dt>
+                <dd className="mb-0 fw-semibold">AED {stats.avgPrice.toLocaleString()}</dd>
+              </div>
+              <div>
+                <dt className="text-muted extra-small text-uppercase">Cities</dt>
+                <dd className="mb-0 fw-semibold">{stats.cities}</dd>
+              </div>
+            </dl>
+            <button
+              type="button"
+              className="btn btn-outline-primary btn-sm d-lg-none"
+              onClick={() => setSidebarOpen((open) => !open)}
+              aria-expanded={isSidebarOpen}
+              aria-controls="app-sidebar"
+            >
+              {isSidebarOpen ? "Close menu" : "Open menu"}
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className={`app-shell ${isSidebarOpen ? "app-shell--sidebar-open" : ""}`}>
+        <button
+          type="button"
+          className={`app-sidebar__backdrop ${isSidebarOpen ? "show" : ""}`}
+          onClick={() => setSidebarOpen(false)}
+          aria-hidden={!isSidebarOpen}
+        />
+        <aside
+          id="app-sidebar"
+          className={`app-sidebar ${isSidebarOpen ? "app-sidebar--open" : ""}`}
+          aria-label="Primary navigation and filters"
+        >
+          <div className="app-sidebar__inner">
+            <div className="app-sidebar__section app-sidebar__section--header">
+              <div>
+                <h2 className="h6 text-uppercase text-muted mb-1">Workspace</h2>
+                <p className="mb-0 fw-semibold">Exploration controls</p>
+              </div>
+              <button
+                type="button"
+                className="btn-close d-lg-none"
+                aria-label="Close sidebar"
+                onClick={() => setSidebarOpen(false)}
+              />
             </div>
 
-            <div className="app-header__stats" aria-label="Dataset summary">
-              <div>
-                <span className="app-header__stat-value text-primary">
-                  {stats.totalListings.toLocaleString()}
-                </span>
-                <span className="app-header__stat-label">Active listings</span>
-              </div>
-              <div>
-                <span className="app-header__stat-value text-success">
-                  AED {stats.avgPrice.toLocaleString()}
-                </span>
-                <span className="app-header__stat-label">Average price</span>
-              </div>
-              <div>
-                <span className="app-header__stat-value text-info">{stats.cities}</span>
-                <span className="app-header__stat-label">Cities covered</span>
-              </div>
-            </div>
+            <section className="app-sidebar__section" aria-label="Dataset summary">
+              <h3 className="app-sidebar__section-title">Summary</h3>
+              <dl className="app-sidebar__stats">
+                <div>
+                  <dt>Active listings</dt>
+                  <dd>{stats.totalListings.toLocaleString()}</dd>
+                </div>
+                <div>
+                  <dt>Average price</dt>
+                  <dd>AED {stats.avgPrice.toLocaleString()}</dd>
+                </div>
+                <div>
+                  <dt>Cities covered</dt>
+                  <dd>{stats.cities}</dd>
+                </div>
+              </dl>
+            </section>
 
-            <div className="app-header__search" role="search">
+            <section className="app-sidebar__section" aria-label="Search listings">
+              <h3 className="app-sidebar__section-title">Search</h3>
               <label className="visually-hidden" htmlFor="global-search-input">
                 Search listings
               </label>
@@ -425,120 +482,136 @@ export default function App() {
               <p className="text-muted extra-small mb-0">
                 Type to filter, press Enter to add custom terms, or pick from suggestions.
               </p>
-            </div>
+            </section>
 
-            <div className="app-header__filters">
-              <select
-                className="form-select form-select-sm"
-                value={cityFilter}
-                onChange={(e) => setCityFilter(e.target.value)}
-                aria-label="Filter by city"
-              >
-                <option value="">All cities</option>
-                {cityOptions.map((c) => (
-                  <option key={c} value={c}>{c}</option>
-                ))}
-              </select>
-              <select
-                className="form-select form-select-sm"
-                value={bodyFilter}
-                onChange={(e) => setBodyFilter(e.target.value)}
-                aria-label="Filter by body type"
-              >
-                <option value="">All bodies</option>
-                {bodyOptions.map((b) => (
-                  <option key={b} value={b}>{b}</option>
-                ))}
-              </select>
-              <div className="app-header__date-filter">
-                <select
-                  className="form-select form-select-sm"
-                  value={dateFilter}
-                  onChange={(e) => setDateFilter(e.target.value)}
-                  aria-label="Filter by listing date"
-                >
-                  <option value="all">All dates</option>
-                  <option value="1d">Last 1 day</option>
-                  <option value="3d">Last 3 days</option>
-                  <option value="1w">Last 1 week</option>
-                  <option value="custom">Last N weeks…</option>
-                </select>
-                {dateFilter === "custom" && (
-                  <input
-                    type="number"
-                    className="form-control form-control-sm"
-                    min="1"
-                    max="52"
-                    step="1"
-                    value={customWeeks}
-                    onChange={(e) => setCustomWeeks(e.target.value)}
-                    placeholder="Weeks"
-                    aria-label="Enter number of weeks"
-                  />
-                )}
+            <section className="app-sidebar__section" aria-label="Filter listings">
+              <h3 className="app-sidebar__section-title">Filters</h3>
+              <div className="app-sidebar__filters">
+                <div>
+                  <label className="form-label form-label-sm" htmlFor="filter-city">City</label>
+                  <select
+                    id="filter-city"
+                    className="form-select form-select-sm"
+                    value={cityFilter}
+                    onChange={(e) => setCityFilter(e.target.value)}
+                  >
+                    <option value="">All cities</option>
+                    {cityOptions.map((c) => (
+                      <option key={c} value={c}>{c}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="form-label form-label-sm" htmlFor="filter-body">Body</label>
+                  <select
+                    id="filter-body"
+                    className="form-select form-select-sm"
+                    value={bodyFilter}
+                    onChange={(e) => setBodyFilter(e.target.value)}
+                  >
+                    <option value="">All bodies</option>
+                    {bodyOptions.map((b) => (
+                      <option key={b} value={b}>{b}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="form-label form-label-sm" htmlFor="filter-date">Listing date</label>
+                  <div className="d-flex gap-2">
+                    <select
+                      id="filter-date"
+                      className="form-select form-select-sm"
+                      value={dateFilter}
+                      onChange={(e) => setDateFilter(e.target.value)}
+                    >
+                      <option value="all">All dates</option>
+                      <option value="1d">Last 1 day</option>
+                      <option value="3d">Last 3 days</option>
+                      <option value="1w">Last 1 week</option>
+                      <option value="custom">Last N weeks…</option>
+                    </select>
+                    {dateFilter === "custom" && (
+                      <input
+                        type="number"
+                        className="form-control form-control-sm"
+                        min="1"
+                        max="52"
+                        step="1"
+                        value={customWeeks}
+                        onChange={(e) => setCustomWeeks(e.target.value)}
+                        placeholder="Weeks"
+                        aria-label="Enter number of weeks"
+                      />
+                    )}
+                  </div>
+                </div>
               </div>
-              <button type="button" className="btn btn-outline-secondary btn-sm" onClick={handleReset}>
-                Reset
+              <button type="button" className="btn btn-outline-secondary btn-sm w-100" onClick={handleReset}>
+                Reset filters
               </button>
-            </div>
+            </section>
 
-            <nav className="app-header__nav" aria-label="Primary">
-              <NavLink
-                to="/"
-                end
-                className={({ isActive }) =>
-                  `btn ${isActive ? "btn-primary" : "btn-outline-primary"} btn-sm px-3`
-                }
-              >
-                📊 Overview
-              </NavLink>
-              <NavLink
-                to="/charts"
-                className={({ isActive }) =>
-                  `btn ${isActive ? "btn-primary" : "btn-outline-primary"} btn-sm px-3`
-                }
-              >
-                📈 Charts
-              </NavLink>
-              <NavLink
-                to="/flippers"
-                className={({ isActive }) =>
-                  `btn ${isActive ? "btn-primary" : "btn-outline-primary"} btn-sm px-3`
-                }
-              >
-                💸 Flippers
-              </NavLink>
-              <NavLink
-                to="/analytics"
-                className={({ isActive }) =>
-                  `btn ${isActive ? "btn-primary" : "btn-outline-primary"} btn-sm px-3`
-                }
-              >
-                🧮 Analytics
-              </NavLink>
+            <nav className="app-sidebar__section" aria-label="Primary">
+              <h3 className="app-sidebar__section-title">Navigate</h3>
+              <div className="app-sidebar__nav">
+                <NavLink
+                  to="/"
+                  end
+                  className={({ isActive }) =>
+                    `app-sidebar__nav-link ${isActive ? "active" : ""}`
+                  }
+                >
+                  📊 Overview
+                </NavLink>
+                <NavLink
+                  to="/charts"
+                  className={({ isActive }) =>
+                    `app-sidebar__nav-link ${isActive ? "active" : ""}`
+                  }
+                >
+                  📈 Charts
+                </NavLink>
+                <NavLink
+                  to="/flippers"
+                  className={({ isActive }) =>
+                    `app-sidebar__nav-link ${isActive ? "active" : ""}`
+                  }
+                >
+                  💸 Flippers
+                </NavLink>
+                <NavLink
+                  to="/analytics"
+                  className={({ isActive }) =>
+                    `app-sidebar__nav-link ${isActive ? "active" : ""}`
+                  }
+                >
+                  🧮 Analytics
+                </NavLink>
+              </div>
             </nav>
           </div>
-        </div>
-      </header>
+        </aside>
 
-      {/* Main Content */}
-      <main className="container-fluid py-3">
-        <Routes>
-          <Route
-            path="/"
-            element={
-              <Overview
-                data={filteredData}
-                resetSignal={resetSignal}
+        <main className="app-main">
+          <div className="app-main__inner container-fluid py-4">
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <Overview
+                    data={filteredData}
+                    resetSignal={resetSignal}
+                  />
+                }
               />
-            }
-          />
-          <Route path="/charts" element={<Charts data={filteredData} />} />
-          <Route path="/flippers" element={<Flippers data={filteredData} dateWindow={dateFilterMeta} />} />
-          <Route path="/analytics" element={<Analytics data={filteredData} />} />
-          <Route path="/car/:id" element={<CarDetail data={data} />} />
-        </Routes>
-      </main>
+              <Route path="/charts" element={<Charts data={filteredData} />} />
+              <Route path="/flippers" element={<Flippers data={filteredData} dateWindow={dateFilterMeta} />} />
+              <Route path="/analytics" element={<Analytics data={filteredData} />} />
+              <Route path="/car/:id" element={<CarDetail data={data} />} />
+            </Routes>
+          </div>
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/components/SearchMultiSelect.jsx
+++ b/src/components/SearchMultiSelect.jsx
@@ -10,6 +10,7 @@ const SearchMultiSelect = ({
   onChange,
   placeholder = "Search…",
   name = "search",
+  id,
   ariaLabel = "Search listings",
 }) => {
   const containerRef = useRef(null);
@@ -118,7 +119,8 @@ const SearchMultiSelect = ({
     }
   };
 
-  const listboxId = `${name}-suggestions`;
+  const inputId = id || name;
+  const listboxId = `${inputId}-suggestions`;
 
   return (
     <div className="search-multiselect" ref={containerRef}>
@@ -150,6 +152,7 @@ const SearchMultiSelect = ({
             ref={inputRef}
             type="text"
             name={name}
+            id={inputId}
             value={query}
             placeholder={value.length ? "Add another…" : placeholder}
             onChange={(event) => {

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -1,4 +1,17 @@
 import React, { useMemo, useState } from "react";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  PieChart,
+  Pie,
+  Cell,
+  Legend
+} from "recharts";
 import { fmtPrice } from "../utils";
 
 const AGGREGATORS = [
@@ -7,6 +20,29 @@ const AGGREGATORS = [
   { value: "sum", label: "Sum", needsField: true },
   { value: "min", label: "Minimum", needsField: true },
   { value: "max", label: "Maximum", needsField: true }
+];
+
+const WIDGET_TYPES = [
+  { value: "metric", label: "Metric card" },
+  { value: "table", label: "Summary table" },
+  { value: "chart", label: "Chart" }
+];
+
+const CHART_VARIANTS = [
+  { value: "bar", label: "Bar" },
+  { value: "pie", label: "Pie" }
+];
+
+const CHART_COLORS = [
+  "#2563eb",
+  "#0ea5e9",
+  "#f97316",
+  "#10b981",
+  "#a855f7",
+  "#facc15",
+  "#f43f5e",
+  "#22d3ee",
+  "#8b5cf6"
 ];
 
 const METRIC_FIELDS = [
@@ -33,6 +69,8 @@ const FILTER_FIELDS = [
   { value: "market_discount_pct", label: "Market Discount %", type: "number" },
   { value: "details_kilometers", label: "Mileage (km)", type: "number" }
 ];
+
+const GROUP_FIELDS = FILTER_FIELDS.filter((field) => field.type === "string" || field.value === "details_year");
 
 const STRING_OPERATORS = [
   { value: "equals", label: "is" },
@@ -62,6 +100,8 @@ FILTER_FIELDS.forEach((field) => {
 let internalId = 0;
 const nextId = (prefix) => `${prefix}-${++internalId}`;
 
+const defaultGroupField = GROUP_FIELDS[0]?.value || "";
+
 const aggregatorNeedsField = (agg) => AGGREGATORS.find((a) => a.value === agg)?.needsField;
 
 const compatibleMetricFields = (aggregator) =>
@@ -79,25 +119,23 @@ const normalizeNumeric = (value) => {
   return Number.isFinite(n) ? n : null;
 };
 
-const computeKpi = (kpi, rows) => {
-  if (!Array.isArray(rows) || !rows.length) {
-    return { value: null, formatted: "—", matches: 0 };
+const applyFilters = (rows, filters) => {
+  if (!Array.isArray(rows) || !rows.length || !Array.isArray(filters) || !filters.length) {
+    return rows;
   }
 
-  const filteredRows = kpi.filters.reduce((accRows, filter) => {
+  return filters.reduce((accRows, filter) => {
     if (!filter.field) return accRows;
     const meta = fieldMetaByValue[filter.field] || { type: "string" };
     const operator = filter.operator || defaultOperatorForType(meta.type);
     const rawValue = filter.value;
     if (rawValue == null || rawValue === "") return accRows;
 
-    const compareValue = meta.type === "number" ? normalizeNumeric(rawValue) : String(rawValue).toLowerCase();
-    if (meta.type === "number" && compareValue == null) return [];
-
-    return accRows.filter((row) => {
-      const cell = row[filter.field];
-      if (meta.type === "number") {
-        const n = normalizeNumeric(cell);
+    if (meta.type === "number") {
+      const compareValue = normalizeNumeric(rawValue);
+      if (compareValue == null) return [];
+      return accRows.filter((row) => {
+        const n = normalizeNumeric(row[filter.field]);
         if (n == null) return false;
         switch (operator) {
           case "eq":
@@ -113,9 +151,12 @@ const computeKpi = (kpi, rows) => {
           default:
             return false;
         }
-      }
+      });
+    }
 
-      const text = String(cell ?? "").toLowerCase();
+    const compareValue = String(rawValue).toLowerCase();
+    return accRows.filter((row) => {
+      const text = String(row[filter.field] ?? "").toLowerCase();
       switch (operator) {
         case "equals":
           return text === compareValue;
@@ -128,54 +169,228 @@ const computeKpi = (kpi, rows) => {
       }
     });
   }, rows);
+};
 
+const formatValue = (value, fieldMeta) => {
+  if (value == null || Number.isNaN(value)) return "—";
+  const meta = fieldMeta || { type: "number" };
+  switch (meta.type) {
+    case "currency":
+      return fmtPrice(Math.round(value));
+    case "percent":
+      return `${Number(value).toFixed(1)}%`;
+    case "count":
+      return Number(value).toLocaleString("en-US");
+    case "number":
+    default: {
+      const precision = Math.abs(value) >= 100 ? 0 : 2;
+      return Number(value).toLocaleString("en-US", { maximumFractionDigits: precision });
+    }
+  }
+};
+
+const aggregateNumericValues = (values, aggregator) => {
+  if (!Array.isArray(values) || !values.length) return null;
+  switch (aggregator) {
+    case "sum":
+      return values.reduce((sum, v) => sum + v, 0);
+    case "avg": {
+      const sum = values.reduce((total, v) => total + v, 0);
+      return sum / values.length;
+    }
+    case "min":
+      return Math.min(...values);
+    case "max":
+      return Math.max(...values);
+    default:
+      return null;
+  }
+};
+
+const computeMetricWidget = (widget, rows) => {
+  const filteredRows = applyFilters(rows, widget.filters);
   const matches = filteredRows.length;
-  if (kpi.aggregator === "count" || !aggregatorNeedsField(kpi.aggregator)) {
-    return { value: matches, formatted: matches.toLocaleString("en-US"), matches };
+  const aggregator = widget.aggregator || "count";
+  const needsField = aggregatorNeedsField(aggregator);
+
+  if (!needsField) {
+    return {
+      type: "metric",
+      aggregator,
+      field: null,
+      fieldMeta: { type: "count", label: "Listings" },
+      value: matches,
+      formatted: matches.toLocaleString("en-US"),
+      matches
+    };
+  }
+
+  if (!widget.field) {
+    return {
+      type: "metric",
+      aggregator,
+      field: null,
+      fieldMeta: null,
+      value: null,
+      formatted: "—",
+      matches,
+      message: "Select a metric field",
+      needsField: true
+    };
   }
 
   const values = filteredRows
-    .map((row) => normalizeNumeric(row[kpi.field]))
+    .map((row) => normalizeNumeric(row[widget.field]))
     .filter((value) => value != null);
 
-  if (!values.length) {
-    return { value: null, formatted: "—", matches };
-  }
-
-  let value = null;
-  switch (kpi.aggregator) {
-    case "sum":
-      value = values.reduce((sum, v) => sum + v, 0);
-      break;
-    case "avg":
-      value = values.reduce((sum, v) => sum + v, 0) / values.length;
-      break;
-    case "min":
-      value = Math.min(...values);
-      break;
-    case "max":
-      value = Math.max(...values);
-      break;
-    default:
-      value = null;
-  }
+  const value = aggregateNumericValues(values, aggregator);
 
   if (value == null) {
-    return { value: null, formatted: "—", matches };
+    return {
+      type: "metric",
+      aggregator,
+      field: widget.field,
+      fieldMeta: fieldMetaByValue[widget.field] || { type: "number", label: widget.field },
+      value: null,
+      formatted: "—",
+      matches,
+      message: "No numeric values available",
+      needsField: true
+    };
   }
 
-  const fieldMeta = fieldMetaByValue[kpi.field] || { type: "number" };
-  let formatted = "";
-  if (fieldMeta.type === "currency") {
-    formatted = fmtPrice(Math.round(value));
-  } else if (fieldMeta.type === "percent") {
-    formatted = `${value.toFixed(1)}%`;
-  } else {
-    const precision = Math.abs(value) >= 100 ? 0 : 2;
-    formatted = Number(value).toLocaleString("en-US", { maximumFractionDigits: precision });
+  const fieldMeta = fieldMetaByValue[widget.field] || { type: "number", label: widget.field };
+  return {
+    type: "metric",
+    aggregator,
+    field: widget.field,
+    fieldMeta,
+    value,
+    formatted: formatValue(value, fieldMeta),
+    matches,
+    samples: values.length
+  };
+};
+
+const sanitizeLimit = (limit) => {
+  const numeric = Number(limit);
+  if (!Number.isFinite(numeric)) return 8;
+  return Math.min(20, Math.max(3, Math.round(numeric)));
+};
+
+const buildGroupedAggregation = (widget, rows) => {
+  const filteredRows = applyFilters(rows, widget.filters);
+  const matches = filteredRows.length;
+  const aggregator = widget.aggregator || "count";
+  const needsField = aggregatorNeedsField(aggregator);
+
+  if (!widget.groupBy) {
+    return { data: [], matches, aggregator, message: "Pick a grouping field to summarise by." };
   }
 
-  return { value, formatted, matches };
+  if (needsField && !widget.field) {
+    return {
+      data: [],
+      matches,
+      aggregator,
+      message: "Select a metric field for this aggregation.",
+      needsField: true
+    };
+  }
+
+  const limit = sanitizeLimit(widget.limit);
+  const groupMeta = fieldMetaByValue[widget.groupBy] || { label: widget.groupBy, type: "string" };
+  const fieldMeta = needsField
+    ? fieldMetaByValue[widget.field] || { label: widget.field, type: "number" }
+    : { label: "Listings", type: "count" };
+
+  const buckets = new Map();
+  filteredRows.forEach((row) => {
+    const rawKey = row[widget.groupBy];
+    const key = rawKey == null || rawKey === "" ? "Unknown" : String(rawKey);
+    const bucket = buckets.get(key) || { key, label: key, rows: [] };
+    bucket.rows.push(row);
+    buckets.set(key, bucket);
+  });
+
+  const aggregated = Array.from(buckets.values())
+    .map((bucket) => {
+      const count = bucket.rows.length;
+      if (aggregator === "count") {
+        const value = count;
+        return {
+          key: bucket.key,
+          label: bucket.label,
+          value,
+          formatted: formatValue(value, { type: "count" }),
+          count,
+          share: matches ? (count / Math.max(matches, 1)) * 100 : 0,
+          samples: count
+        };
+      }
+
+      const numericValues = bucket.rows
+        .map((row) => normalizeNumeric(row[widget.field]))
+        .filter((value) => value != null);
+
+      const value = aggregateNumericValues(numericValues, aggregator);
+      if (value == null) return null;
+
+      return {
+        key: bucket.key,
+        label: bucket.label,
+        value,
+        formatted: formatValue(value, fieldMeta),
+        count,
+        share: matches ? (count / Math.max(matches, 1)) * 100 : 0,
+        samples: numericValues.length
+      };
+    })
+    .filter(Boolean);
+
+  if (!aggregated.length) {
+    const message = matches === 0 ? "No listings match the current filters." : "Not enough data to compute this view.";
+    return { data: [], matches, aggregator, message, fieldMeta, groupMeta };
+  }
+
+  aggregated.sort((a, b) => {
+    if (aggregator === "min") {
+      return a.value - b.value;
+    }
+    return b.value - a.value;
+  });
+
+  return {
+    data: aggregated.slice(0, limit),
+    matches,
+    aggregator,
+    fieldMeta,
+    groupMeta,
+    limit
+  };
+};
+
+const computeTableWidget = (widget, rows) => ({
+  type: "table",
+  ...buildGroupedAggregation(widget, rows)
+});
+
+const computeChartWidget = (widget, rows) => ({
+  type: "chart",
+  variant: widget.chartVariant || "bar",
+  ...buildGroupedAggregation(widget, rows)
+});
+
+const computeWidget = (widget, rows) => {
+  switch (widget.type) {
+    case "table":
+      return computeTableWidget(widget, rows);
+    case "chart":
+      return computeChartWidget(widget, rows);
+    case "metric":
+    default:
+      return computeMetricWidget(widget, rows);
+  }
 };
 
 const buildFilterOptions = (data) => {
@@ -195,25 +410,29 @@ const buildFilterOptions = (data) => {
 };
 
 const Analytics = ({ data }) => {
-  const [kpis, setKpis] = useState(() => [
+  const [widgets, setWidgets] = useState(() => [
     {
-      id: nextId("kpi"),
+      id: nextId("widget"),
       name: "Active listings",
+      type: "metric",
       aggregator: "count",
       field: null,
+      groupBy: defaultGroupField,
+      chartVariant: "bar",
+      limit: 8,
       filters: []
     }
   ]);
 
   const suggestions = useMemo(() => buildFilterOptions(data), [data]);
 
-  const kpiResults = useMemo(
+  const widgetResults = useMemo(
     () =>
-      kpis.map((kpi) => ({
-        id: kpi.id,
-        result: computeKpi(kpi, data)
+      widgets.map((widget) => ({
+        id: widget.id,
+        result: computeWidget(widget, data)
       })),
-    [kpis, data]
+    [widgets, data]
   );
 
   const datasetSize = data.length;
@@ -338,39 +557,41 @@ const Analytics = ({ data }) => {
       .slice(0, 5);
   }, [data, datasetSize]);
 
-  const updateKpi = (id, updater) => {
-    setKpis((prev) =>
-      prev.map((kpi) => (kpi.id === id ? { ...kpi, ...updater(kpi) } : kpi))
+  const updateWidget = (id, updater) => {
+    setWidgets((prev) =>
+      prev.map((widget) => (widget.id === id ? { ...widget, ...updater(widget) } : widget))
     );
   };
 
-  const addKpi = () => {
-    const defaultAgg = "avg";
-    const field = defaultMetricForAggregator(defaultAgg);
-    setKpis((prev) => [
+  const addWidget = () => {
+    setWidgets((prev) => [
       ...prev,
       {
-        id: nextId("kpi"),
-        name: "New KPI",
-        aggregator: field ? defaultAgg : "count",
-        field: field ?? null,
+        id: nextId("widget"),
+        name: "New insight",
+        type: "metric",
+        aggregator: "count",
+        field: null,
+        groupBy: defaultGroupField,
+        chartVariant: "bar",
+        limit: 8,
         filters: []
       }
     ]);
   };
 
-  const removeKpi = (id) => {
-    setKpis((prev) => (prev.length > 1 ? prev.filter((kpi) => kpi.id !== id) : prev));
+  const removeWidget = (id) => {
+    setWidgets((prev) => (prev.length > 1 ? prev.filter((widget) => widget.id !== id) : prev));
   };
 
-  const addFilter = (kpiId) => {
-    setKpis((prev) =>
-      prev.map((kpi) =>
-        kpi.id === kpiId
+  const addFilter = (widgetId) => {
+    setWidgets((prev) =>
+      prev.map((widget) =>
+        widget.id === widgetId
           ? {
-              ...kpi,
+              ...widget,
               filters: [
-                ...kpi.filters,
+                ...widget.filters,
                 {
                   id: nextId("filter"),
                   field: "",
@@ -379,29 +600,29 @@ const Analytics = ({ data }) => {
                 }
               ]
             }
-          : kpi
+          : widget
       )
     );
   };
 
-  const updateFilter = (kpiId, filterId, patch) => {
-    setKpis((prev) =>
-      prev.map((kpi) => {
-        if (kpi.id !== kpiId) return kpi;
-        const filters = kpi.filters.map((filter) =>
+  const updateFilter = (widgetId, filterId, patch) => {
+    setWidgets((prev) =>
+      prev.map((widget) => {
+        if (widget.id !== widgetId) return widget;
+        const filters = widget.filters.map((filter) =>
           filter.id === filterId ? { ...filter, ...patch(filter) } : filter
         );
-        return { ...kpi, filters };
+        return { ...widget, filters };
       })
     );
   };
 
-  const removeFilter = (kpiId, filterId) => {
-    setKpis((prev) =>
-      prev.map((kpi) =>
-        kpi.id === kpiId
-          ? { ...kpi, filters: kpi.filters.filter((filter) => filter.id !== filterId) }
-          : kpi
+  const removeFilter = (widgetId, filterId) => {
+    setWidgets((prev) =>
+      prev.map((widget) =>
+        widget.id === widgetId
+          ? { ...widget, filters: widget.filters.filter((filter) => filter.id !== filterId) }
+          : widget
       )
     );
   };
@@ -534,259 +755,430 @@ const Analytics = ({ data }) => {
       <section className="analytics-kpis">
         <div className="d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-2 mb-3">
           <div>
-            <h3 className="h5 mb-1">Custom KPI builder</h3>
-            <p className="text-muted mb-0">Mix and match aggregations with flexible filters for on-the-fly analysis.</p>
+            <h3 className="h5 mb-1">Custom insight builder</h3>
+            <p className="text-muted mb-0">Mix and match metrics, tables, and charts that update with your sidebar filters.</p>
           </div>
           <div>
-            <button type="button" className="btn btn-primary" onClick={addKpi}>
-              + Add KPI
+            <button type="button" className="btn btn-primary" onClick={addWidget}>
+              + Add widget
             </button>
           </div>
         </div>
 
         <div className="row g-3">
-          {kpis.map((kpi, index) => {
-            const aggregator = AGGREGATORS.find((agg) => agg.value === kpi.aggregator) || AGGREGATORS[0];
-            const needsField = aggregator.needsField;
-            const metricMeta = needsField ? fieldMetaByValue[kpi.field] : null;
-            const compatibleFields = needsField ? compatibleMetricFields(aggregator.value) : [];
-          const result = kpiResults.find((r) => r.id === kpi.id)?.result ?? { formatted: "—", matches: 0 };
-          const matchesText = Number.isFinite(result.matches)
-            ? result.matches.toLocaleString("en-US")
-            : "0";
-          const detailText = needsField && metricMeta
-            ? `${aggregator.label} of ${metricMeta.label}`
-            : `${aggregator.label} of listings`;
+          {widgets.map((widget, index) => {
+            const aggregator = AGGREGATORS.find((agg) => agg.value === widget.aggregator) || AGGREGATORS[0];
+            const needsField = aggregatorNeedsField(widget.aggregator);
+            const metricOptions = needsField ? compatibleMetricFields(widget.aggregator) : [];
+            const widgetResult = widgetResults.find((entry) => entry.id === widget.id)?.result ?? { formatted: "—", matches: 0, data: [] };
+            const fieldMeta = widget.field ? fieldMetaByValue[widget.field] : null;
+            const groupMeta = widget.groupBy ? fieldMetaByValue[widget.groupBy] : null;
+            const resultFieldMeta = widgetResult.fieldMeta || fieldMeta || { label: "Metric" };
+            const matchesText = Number.isFinite(widgetResult.matches)
+              ? widgetResult.matches.toLocaleString("en-US")
+              : "0";
+            const aggregatorLabel = aggregator.label;
+            const groupLabel = groupMeta?.label || "Group";
+            const detailText = widget.type === "metric"
+              ? needsField && fieldMeta
+                ? `${aggregatorLabel} of ${fieldMeta.label}`
+                : `${aggregatorLabel} of listings`
+              : needsField && fieldMeta
+                ? `${aggregatorLabel} of ${fieldMeta.label} by ${groupLabel}`
+                : `${aggregatorLabel} of listings by ${groupLabel}`;
+            const previewData = Array.isArray(widgetResult.data) ? widgetResult.data : [];
+            const limitValue = widget.limit ?? 8;
+            const rotateLabels = previewData.length > 8;
 
-          return (
-            <div className="col-12 col-lg-6" key={kpi.id}>
-              <div className="card border-0 shadow-sm h-100">
-                <div className="card-body d-flex flex-column gap-3">
-                  <div className="d-flex align-items-start justify-content-between gap-2">
-                    <div className="flex-grow-1">
-                      <input
-                        type="text"
-                        className="form-control form-control-sm"
-                        value={kpi.name}
-                        onChange={(e) => updateKpi(kpi.id, () => ({ name: e.target.value }))}
-                        placeholder="Name your KPI"
-                        aria-label="KPI name"
-                      />
-                    </div>
-                    <button
-                      type="button"
-                      className="btn btn-outline-danger btn-sm"
-                      onClick={() => removeKpi(kpi.id)}
-                      disabled={kpis.length === 1 && index === 0}
-                    >
-                      Remove
-                    </button>
-                  </div>
-
-                  <div className="d-flex flex-column flex-md-row gap-2">
-                    <div className="flex-grow-1">
-                      <label className="form-label form-label-sm mb-1">Aggregator</label>
-                      <select
-                        className="form-select form-select-sm"
-                        value={kpi.aggregator}
-                        onChange={(e) => {
-                          const nextAgg = e.target.value;
-                          const needs = aggregatorNeedsField(nextAgg);
-                          updateKpi(kpi.id, (current) => {
-                            let nextField = current.field;
-                            if (needs) {
-                              const allowed = compatibleMetricFields(nextAgg);
-                              if (!allowed.find((field) => field.value === nextField)) {
-                                nextField = allowed.length ? allowed[0].value : null;
-                              }
-                            } else {
-                              nextField = null;
-                            }
-                            return { aggregator: nextAgg, field: nextField };
-                          });
-                        }}
-                        aria-label="Select aggregator"
-                      >
-                        {AGGREGATORS.map((option) => (
-                          <option
-                            key={option.value}
-                            value={option.value}
-                            disabled={option.needsField && !compatibleMetricFields(option.value).length}
-                          >
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-
-                    {needsField && (
+            return (
+              <div className="col-12 col-xl-6" key={widget.id}>
+                <div className="card border-0 shadow-sm h-100 analytics-widget">
+                  <div className="card-body d-flex flex-column gap-3">
+                    <div className="d-flex flex-column flex-md-row gap-2 align-items-md-start justify-content-between">
                       <div className="flex-grow-1">
-                        <label className="form-label form-label-sm mb-1">Metric</label>
+                        <input
+                          type="text"
+                          className="form-control form-control-sm"
+                          value={widget.name}
+                          onChange={(e) => updateWidget(widget.id, () => ({ name: e.target.value }))}
+                          placeholder="Name your insight"
+                          aria-label="Widget name"
+                        />
+                      </div>
+                      <div className="d-flex align-items-center gap-2">
                         <select
                           className="form-select form-select-sm"
-                          value={kpi.field ?? ""}
+                          value={widget.type}
                           onChange={(e) => {
-                            const nextField = e.target.value || null;
-                            updateKpi(kpi.id, (current) => {
-                              if (!nextField) return { field: null };
-                              const meta = fieldMetaByValue[nextField];
-                              const allowedAgg = meta?.aggregators || [];
-                              let nextAgg = current.aggregator;
-                              if (!allowedAgg.includes(nextAgg)) {
-                                nextAgg = allowedAgg.length ? allowedAgg[0] : "count";
+                            const nextType = e.target.value;
+                            updateWidget(widget.id, (current) => ({
+                              type: nextType,
+                              aggregator: "count",
+                              field: null,
+                              groupBy: current.groupBy || defaultGroupField,
+                              chartVariant: nextType === "chart" ? current.chartVariant || "bar" : current.chartVariant || "bar",
+                              limit: current.limit || 8
+                            }));
+                          }}
+                          aria-label="Select widget type"
+                        >
+                          {WIDGET_TYPES.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                        <button
+                          type="button"
+                          className="btn btn-outline-danger btn-sm"
+                          onClick={() => removeWidget(widget.id)}
+                          disabled={widgets.length === 1 && index === 0}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="row g-2">
+                      <div className="col-12 col-md-4">
+                        <label className="form-label form-label-sm mb-1">Aggregator</label>
+                        <select
+                          className="form-select form-select-sm"
+                          value={widget.aggregator}
+                          onChange={(e) => {
+                            const nextAgg = e.target.value;
+                            const needs = aggregatorNeedsField(nextAgg);
+                            updateWidget(widget.id, (current) => {
+                              let nextField = current.field;
+                              if (needs) {
+                                const allowed = compatibleMetricFields(nextAgg);
+                                if (!allowed.find((field) => field.value === nextField)) {
+                                  nextField = allowed.length ? allowed[0].value : null;
+                                }
+                              } else {
+                                nextField = null;
                               }
-                              return { field: nextField, aggregator: nextAgg };
+                              return { aggregator: nextAgg, field: nextField };
                             });
                           }}
-                          aria-label="Select metric field"
+                          aria-label="Select aggregator"
                         >
-                          {compatibleFields.map((field) => (
-                            <option key={field.value} value={field.value}>
-                              {field.label}
+                          {AGGREGATORS.map((option) => (
+                            <option
+                              key={option.value}
+                              value={option.value}
+                              disabled={option.needsField && !compatibleMetricFields(option.value).length}
+                            >
+                              {option.label}
                             </option>
                           ))}
                         </select>
                       </div>
-                    )}
-                  </div>
 
-                  <div className="bg-light rounded p-3">
-                    <div className="d-flex align-items-center justify-content-between mb-2">
-                      <h3 className="h6 mb-0">Filters</h3>
-                      <button
-                        type="button"
-                        className="btn btn-outline-primary btn-sm"
-                        onClick={() => addFilter(kpi.id)}
-                      >
-                        + Add filter
-                      </button>
+                      {needsField && (
+                        <div className="col-12 col-md-4">
+                          <label className="form-label form-label-sm mb-1">Metric</label>
+                          <select
+                            className="form-select form-select-sm"
+                            value={widget.field ?? ""}
+                            onChange={(e) => {
+                              const nextField = e.target.value || null;
+                              updateWidget(widget.id, (current) => {
+                                if (!nextField) return { field: null };
+                                const meta = fieldMetaByValue[nextField];
+                                const allowedAgg = meta?.aggregators || [];
+                                let nextAgg = current.aggregator;
+                                if (!allowedAgg.includes(nextAgg)) {
+                                  nextAgg = allowedAgg.length ? allowedAgg[0] : "count";
+                                }
+                                return { field: nextField, aggregator: nextAgg };
+                              });
+                            }}
+                            aria-label="Select metric field"
+                          >
+                            {metricOptions.map((field) => (
+                              <option key={field.value} value={field.value}>
+                                {field.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      )}
+
+                      {widget.type !== "metric" && (
+                        <div className="col-12 col-md-4">
+                          <label className="form-label form-label-sm mb-1">Group by</label>
+                          <select
+                            className="form-select form-select-sm"
+                            value={widget.groupBy ?? ""}
+                            onChange={(e) => updateWidget(widget.id, () => ({ groupBy: e.target.value }))}
+                            aria-label="Select grouping field"
+                          >
+                            {GROUP_FIELDS.map((field) => (
+                              <option key={field.value} value={field.value}>
+                                {field.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      )}
+
+                      {widget.type !== "metric" && (
+                        <div className="col-12 col-md-4 col-lg-3">
+                          <label className="form-label form-label-sm mb-1">Top results</label>
+                          <input
+                            type="number"
+                            className="form-control form-control-sm"
+                            min="3"
+                            max="20"
+                            step="1"
+                            value={limitValue}
+                            onChange={(e) => updateWidget(widget.id, () => ({ limit: e.target.value }))}
+                            aria-label="Limit number of rows"
+                          />
+                        </div>
+                      )}
+
+                      {widget.type === "chart" && (
+                        <div className="col-12 col-md-4 col-lg-3">
+                          <label className="form-label form-label-sm mb-1">Chart style</label>
+                          <select
+                            className="form-select form-select-sm"
+                            value={widget.chartVariant ?? "bar"}
+                            onChange={(e) => updateWidget(widget.id, () => ({ chartVariant: e.target.value }))}
+                            aria-label="Select chart variant"
+                          >
+                            {CHART_VARIANTS.map((variant) => (
+                              <option key={variant.value} value={variant.value}>
+                                {variant.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      )}
                     </div>
 
-                    {kpi.filters.length === 0 ? (
-                      <p className="text-muted small mb-0">No filters applied. This KPI uses the full filtered dataset.</p>
-                    ) : (
-                      <div className="d-flex flex-column gap-2">
-                        {kpi.filters.map((filter) => {
-                          const meta = fieldMetaByValue[filter.field] || {};
-                          const isNumber = meta.type === "number";
-                          const operators = isNumber ? NUMBER_OPERATORS : STRING_OPERATORS;
-                          const valueOptions = suggestions[filter.field] || [];
-                          const fieldId = `${filter.id}-field`;
-                          const operatorId = `${filter.id}-operator`;
-                          const valueId = `${filter.id}-value`;
+                    <div className="bg-light rounded p-3">
+                      <div className="d-flex align-items-center justify-content-between mb-2">
+                        <h3 className="h6 mb-0">Filters</h3>
+                        <button
+                          type="button"
+                          className="btn btn-outline-primary btn-sm"
+                          onClick={() => addFilter(widget.id)}
+                        >
+                          + Add filter
+                        </button>
+                      </div>
 
-                          return (
-                            <div className="border rounded p-2" key={filter.id}>
-                              <div className="row g-2 align-items-end">
-                                <div className="col-12 col-md-4">
-                                  <label className="form-label form-label-sm mb-1" htmlFor={fieldId}>Field</label>
-                                  <select
-                                    className="form-select form-select-sm"
-                                    value={filter.field}
-                                    onChange={(e) => {
-                                      const nextField = e.target.value;
-                                      const nextMeta = fieldMetaByValue[nextField] || { type: "string" };
-                                      updateFilter(kpi.id, filter.id, () => ({
-                                        field: nextField,
-                                        operator: defaultOperatorForType(nextMeta.type),
-                                        value: ""
-                                      }));
-                                    }}
-                                    aria-label="Filter field"
-                                    id={fieldId}
-                                  >
-                                    <option value="">Select field…</option>
-                                    {FILTER_FIELDS.map((field) => (
-                                      <option key={field.value} value={field.value}>
-                                        {field.label}
-                                      </option>
-                                    ))}
-                                  </select>
-                                </div>
+                      {widget.filters.length === 0 ? (
+                        <p className="text-muted small mb-0">No filters applied. This widget uses the globally filtered dataset.</p>
+                      ) : (
+                        <div className="d-flex flex-column gap-2">
+                          {widget.filters.map((filter) => {
+                            const meta = fieldMetaByValue[filter.field] || {};
+                            const isNumber = meta.type === "number";
+                            const operators = isNumber ? NUMBER_OPERATORS : STRING_OPERATORS;
+                            const valueOptions = suggestions[filter.field] || [];
+                            const fieldId = `${filter.id}-field`;
+                            const operatorId = `${filter.id}-operator`;
+                            const valueId = `${filter.id}-value`;
 
-                                <div className="col-12 col-md-3">
-                                  <label className="form-label form-label-sm mb-1" htmlFor={operatorId}>Operator</label>
-                                  <select
-                                    className="form-select form-select-sm"
-                                    value={filter.operator}
-                                    onChange={(e) => {
-                                      const nextOperator = e.target.value;
-                                      updateFilter(kpi.id, filter.id, () => ({ operator: nextOperator }));
-                                    }}
-                                    aria-label="Filter operator"
-                                    disabled={!filter.field}
-                                    id={operatorId}
-                                  >
-                                    <option value="">Select…</option>
-                                    {operators.map((op) => (
-                                      <option key={op.value} value={op.value}>
-                                        {op.label}
-                                      </option>
-                                    ))}
-                                  </select>
-                                </div>
-
-                                <div className="col-12 col-md-4">
-                                  <label className="form-label form-label-sm mb-1" htmlFor={valueId}>Value</label>
-                                  {isNumber ? (
-                                    <input
-                                      type="number"
-                                      className="form-control form-control-sm"
-                                      value={filter.value}
-                                      onChange={(e) => updateFilter(kpi.id, filter.id, () => ({ value: e.target.value }))}
-                                      aria-label="Numeric filter value"
-                                      disabled={!filter.operator}
-                                      id={valueId}
-                                    />
-                                  ) : (
-                                    <input
-                                      type="text"
-                                      className="form-control form-control-sm"
-                                      value={filter.value}
-                                      onChange={(e) => updateFilter(kpi.id, filter.id, () => ({ value: e.target.value }))}
-                                      list={valueOptions.length ? `${filter.id}-options` : undefined}
-                                      aria-label="Filter value"
-                                      disabled={!filter.operator}
-                                      id={valueId}
-                                    />
-                                  )}
-                                  {!isNumber && valueOptions.length ? (
-                                    <datalist id={`${filter.id}-options`}>
-                                      {valueOptions.map((val) => (
-                                        <option key={val} value={val} />
+                            return (
+                              <div className="border rounded p-2" key={filter.id}>
+                                <div className="row g-2 align-items-end">
+                                  <div className="col-12 col-md-4">
+                                    <label className="form-label form-label-sm mb-1" htmlFor={fieldId}>Field</label>
+                                    <select
+                                      className="form-select form-select-sm"
+                                      value={filter.field}
+                                      onChange={(e) => {
+                                        const nextField = e.target.value;
+                                        const nextMeta = fieldMetaByValue[nextField] || { type: "string" };
+                                        updateFilter(widget.id, filter.id, () => ({
+                                          field: nextField,
+                                          operator: defaultOperatorForType(nextMeta.type),
+                                          value: ""
+                                        }));
+                                      }}
+                                      aria-label="Filter field"
+                                      id={fieldId}
+                                    >
+                                      <option value="">Select field…</option>
+                                      {FILTER_FIELDS.map((field) => (
+                                        <option key={field.value} value={field.value}>
+                                          {field.label}
+                                        </option>
                                       ))}
-                                    </datalist>
-                                  ) : null}
-                                </div>
+                                    </select>
+                                  </div>
 
-                                <div className="col-12 col-md-1 d-flex justify-content-md-center">
-                                  <button
-                                    type="button"
-                                    className="btn btn-outline-secondary btn-sm w-100"
-                                    onClick={() => removeFilter(kpi.id, filter.id)}
-                                  >
-                                    ✕
-                                  </button>
+                                  <div className="col-12 col-md-3">
+                                    <label className="form-label form-label-sm mb-1" htmlFor={operatorId}>Operator</label>
+                                    <select
+                                      className="form-select form-select-sm"
+                                      value={filter.operator}
+                                      onChange={(e) => {
+                                        const nextOperator = e.target.value;
+                                        updateFilter(widget.id, filter.id, () => ({ operator: nextOperator }));
+                                      }}
+                                      aria-label="Filter operator"
+                                      disabled={!filter.field}
+                                      id={operatorId}
+                                    >
+                                      <option value="">Select…</option>
+                                      {operators.map((op) => (
+                                        <option key={op.value} value={op.value}>
+                                          {op.label}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </div>
+
+                                  <div className="col-12 col-md-4">
+                                    <label className="form-label form-label-sm mb-1" htmlFor={valueId}>Value</label>
+                                    {isNumber ? (
+                                      <input
+                                        type="number"
+                                        className="form-control form-control-sm"
+                                        value={filter.value}
+                                        onChange={(e) => updateFilter(widget.id, filter.id, () => ({ value: e.target.value }))}
+                                        aria-label="Numeric filter value"
+                                        disabled={!filter.operator}
+                                        id={valueId}
+                                      />
+                                    ) : (
+                                      <input
+                                        type="text"
+                                        className="form-control form-control-sm"
+                                        value={filter.value}
+                                        onChange={(e) => updateFilter(widget.id, filter.id, () => ({ value: e.target.value }))}
+                                        list={valueOptions.length ? `${filter.id}-options` : undefined}
+                                        aria-label="Filter value"
+                                        disabled={!filter.operator}
+                                        id={valueId}
+                                      />
+                                    )}
+                                    {!isNumber && valueOptions.length ? (
+                                      <datalist id={`${filter.id}-options`}>
+                                        {valueOptions.map((val) => (
+                                          <option key={val} value={val} />
+                                        ))}
+                                      </datalist>
+                                    ) : null}
+                                  </div>
+
+                                  <div className="col-12 col-md-1 d-flex justify-content-md-center">
+                                    <button
+                                      type="button"
+                                      className="btn btn-outline-secondary btn-sm w-100"
+                                      onClick={() => removeFilter(widget.id, filter.id)}
+                                    >
+                                      ✕
+                                    </button>
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          );
-                        })}
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+
+                    {widget.type === "metric" ? (
+                      <div>
+                        <div className="text-muted small mb-1">Result</div>
+                        <div className="display-6 text-primary">{widgetResult.formatted ?? "—"}</div>
+                        <div className="text-muted small">{detailText}</div>
+                        <div className="text-muted small">Matches {matchesText} listings</div>
+                        {widgetResult.message && (
+                          <div className="text-warning small mt-2">{widgetResult.message}</div>
+                        )}
+                      </div>
+                    ) : widget.type === "table" ? (
+                      <div className="d-flex flex-column gap-2">
+                        <div className="text-muted small">Preview</div>
+                        {widgetResult.message ? (
+                          <p className="text-muted small mb-0">{widgetResult.message}</p>
+                        ) : previewData.length === 0 ? (
+                          <p className="text-muted small mb-0">Not enough data to render a table yet.</p>
+                        ) : (
+                          <div className="table-responsive">
+                            <table className="table table-sm align-middle mb-0" aria-label={`Summary by ${groupLabel}`}>
+                              <thead>
+                                <tr>
+                                  <th scope="col">{groupLabel}</th>
+                                  <th scope="col" className="text-end">{resultFieldMeta.label}</th>
+                                  <th scope="col" className="text-end">Share</th>
+                                  <th scope="col" className="text-end">Listings</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {previewData.map((entry) => (
+                                  <tr key={entry.key}>
+                                    <th scope="row">{entry.label}</th>
+                                    <td className="text-end">{entry.formatted}</td>
+                                    <td className="text-end">{entry.share.toFixed(1)}%</td>
+                                    <td className="text-end">{entry.count.toLocaleString("en-US")}</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        )}
+                        <div className="text-muted extra-small">Top {previewData.length} rows · Matches {matchesText} listings</div>
+                      </div>
+                    ) : (
+                      <div className="analytics-widget__chart">
+                        <div className="text-muted small mb-2">Preview</div>
+                        {widgetResult.message ? (
+                          <p className="text-muted small mb-0">{widgetResult.message}</p>
+                        ) : previewData.length === 0 ? (
+                          <p className="text-muted small mb-0">Not enough data to draw this chart.</p>
+                        ) : (
+                          <ResponsiveContainer width="100%" height={260}>
+                            {widget.chartVariant === "pie" ? (
+                              <PieChart>
+                                <Tooltip formatter={(value, name) => [formatValue(value, widgetResult.fieldMeta), name]} />
+                                <Legend />
+                                <Pie
+                                  data={previewData}
+                                  dataKey="value"
+                                  nameKey="label"
+                                  innerRadius={50}
+                                  outerRadius={95}
+                                  paddingAngle={3}
+                                >
+                                  {previewData.map((entry, idx) => (
+                                    <Cell key={entry.key} fill={CHART_COLORS[idx % CHART_COLORS.length]} />
+                                  ))}
+                                </Pie>
+                              </PieChart>
+                            ) : (
+                              <BarChart data={previewData}>
+                                <CartesianGrid strokeDasharray="3 3" />
+                                <XAxis
+                                  dataKey="label"
+                                  interval={0}
+                                  angle={rotateLabels ? -40 : 0}
+                                  textAnchor={rotateLabels ? "end" : "middle"}
+                                  height={rotateLabels ? 80 : 40}
+                                  tick={{ fontSize: rotateLabels ? 11 : 12 }}
+                                />
+                                <YAxis />
+                                <Tooltip formatter={(value, name) => [formatValue(value, widgetResult.fieldMeta), name]} />
+                                <Bar dataKey="value" fill="#2563eb" radius={[6, 6, 0, 0]} />
+                              </BarChart>
+                            )}
+                          </ResponsiveContainer>
+                        )}
+                        <div className="text-muted extra-small mt-2">Top {previewData.length} groups · Matches {matchesText} listings</div>
                       </div>
                     )}
                   </div>
-
-                  <div>
-                    <div className="text-muted small mb-1">Result</div>
-                    <div className="display-6 text-primary">{result.formatted}</div>
-                    <div className="text-muted small">{detailText}</div>
-                    <div className="text-muted small">Matches {matchesText} listings</div>
-                  </div>
                 </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
         </div>
       </section>
     </div>

--- a/src/pages/Charts.jsx
+++ b/src/pages/Charts.jsx
@@ -1,66 +1,178 @@
 import React, { useMemo } from "react";
 import {
-  ResponsiveContainer, ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip,
-  BarChart, Bar, LineChart, Line
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  BarChart,
+  Bar,
+  Line,
+  Area,
+  PieChart,
+  Pie,
+  Cell,
+  Legend,
+  ComposedChart
 } from "recharts";
 import { groupBy, safeAvg } from "../utils";
 
+const COLOR_PALETTE = [
+  "#2563eb",
+  "#0ea5e9",
+  "#10b981",
+  "#f97316",
+  "#f43f5e",
+  "#a855f7",
+  "#facc15",
+  "#22d3ee",
+  "#8b5cf6",
+  "#14b8a6"
+];
+
 export default function Charts({ data }) {
-  // Price vs Year
-  const scatterData = useMemo(() => {
+  const totalListings = data.length;
+
+  const yearScatterData = useMemo(() => {
     return data
-      .filter(d => Number.isFinite(d.price) && Number.isFinite(d.details_year))
-      .map(d => ({
-        x: Number(d.details_year),
-        y: Number(d.price),
-        title: d.title_en ?? "",
-        city: d.city_inferred ?? "",
-        make: d.details_make || d.brand || ""
+      .filter((row) => Number.isFinite(row.price) && Number.isFinite(row.details_year))
+      .map((row) => ({
+        year: Number(row.details_year),
+        price: Number(row.price),
+        make: row.details_make || row.brand || "Unknown",
+        city: row.city_inferred || "Unknown"
       }));
   }, [data]);
 
-  // Avg price by Make (Top 15)
-  const byMake = useMemo(() => {
-    const rows = data.map(d => ({
-      make: d.details_make || d.brand || "Unknown",
-      price: Number(d.price)
-    })).filter(r => Number.isFinite(r.price));
-    const g = groupBy(rows, r => r.make);
-    const out = Object.keys(g).map(k => ({ make: k, avgPrice: safeAvg(g[k].map(x => x.price)) || 0 }));
-    return out.sort((a,b) => b.avgPrice - a.avgPrice).slice(0, 15);
+  const mileageScatterData = useMemo(() => {
+    return data
+      .filter((row) => Number.isFinite(row.price) && Number.isFinite(row.details_kilometers))
+      .map((row) => ({
+        kilometers: Number(row.details_kilometers),
+        price: Number(row.price),
+        make: row.details_make || row.brand || "Unknown",
+        year: Number(row.details_year) || null
+      }));
   }, [data]);
 
-  // Average price over time (by day) from actual timestamps
-  const byDate = useMemo(() => {
-    const rows = data.filter(d => Number.isFinite(d.created_at_epoch_ms) && Number.isFinite(d.price));
-    const g = groupBy(rows, d => new Date(d.created_at_epoch_ms).toISOString().slice(0,10)); // YYYY-MM-DD
-    const out = Object.keys(g).map(date => ({
-      date,
-      avgPrice: safeAvg(g[date].map(x => x.price))
-    })).sort((a,b) => a.date.localeCompare(b.date));
-    return out;
+  const priceByMake = useMemo(() => {
+    const rows = data
+      .map((row) => ({
+        make: row.details_make || row.brand || "Unknown",
+        price: Number(row.price)
+      }))
+      .filter((row) => Number.isFinite(row.price));
+    const grouped = groupBy(rows, (row) => row.make);
+    return Object.entries(grouped)
+      .map(([make, values]) => ({
+        make,
+        avgPrice: safeAvg(values.map((item) => item.price)) || 0,
+        count: values.length
+      }))
+      .filter((entry) => entry.count >= 5)
+      .sort((a, b) => b.avgPrice - a.avgPrice)
+      .slice(0, 12);
   }, [data]);
 
-  const latestDate = byDate.length ? byDate[byDate.length - 1].date : null;
-  const latestPoint = latestDate ? byDate.filter(p => p.date === latestDate) : [];
+  const bodyTypeShare = useMemo(() => {
+    const grouped = groupBy(
+      data.map((row) => {
+        const value = row.details_body_type || row.body_type || "Unknown";
+        return typeof value === "string" && value.trim() ? value.trim() : "Unknown";
+      }),
+      (value) => value
+    );
+    return Object.entries(grouped)
+      .map(([body, values]) => ({
+        body,
+        count: values.length,
+        share: totalListings ? (values.length / totalListings) * 100 : 0
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 8);
+  }, [data, totalListings]);
+
+  const discountByMake = useMemo(() => {
+    const rows = data
+      .map((row) => ({
+        make: row.details_make || row.brand || "Unknown",
+        discount: Number(row.market_discount_pct)
+      }))
+      .filter((row) => Number.isFinite(row.discount));
+    const grouped = groupBy(rows, (row) => row.make);
+    return Object.entries(grouped)
+      .map(([make, values]) => ({
+        make,
+        avgDiscount: safeAvg(values.map((item) => item.discount)) || 0,
+        samples: values.length
+      }))
+      .filter((entry) => entry.samples >= 5)
+      .sort((a, b) => b.avgDiscount - a.avgDiscount)
+      .slice(0, 10);
+  }, [data]);
+
+  const priceVolumeByDate = useMemo(() => {
+    const grouped = groupBy(
+      data.filter((row) => Number.isFinite(row.created_at_epoch_ms)),
+      (row) => new Date(row.created_at_epoch_ms).toISOString().slice(0, 10)
+    );
+    return Object.entries(grouped)
+      .map(([date, values]) => {
+        const priceValues = values
+          .map((row) => Number(row.price))
+          .filter((value) => Number.isFinite(value));
+        return {
+          date,
+          avgPrice: priceValues.length ? safeAvg(priceValues) : 0,
+          count: values.length
+        };
+      })
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }, [data]);
+
+  const latestSnapshot = priceVolumeByDate[priceVolumeByDate.length - 1];
+
+  const formatCurrency = (value) => `AED ${Math.round(value ?? 0).toLocaleString("en-US")}`;
+  const formatPercent = (value) => `${(value ?? 0).toFixed(1)}%`;
 
   return (
     <div className="container-fluid">
-      <div className="row">
+      <div className="row g-4">
         <div className="col-12">
-          <div className="card border-0 shadow-sm mb-4">
+          <div className="card border-0 shadow-sm h-100">
             <div className="card-header bg-white border-0 pb-0">
-              <h3 className="card-title h4 mb-0">Price vs Year</h3>
+              <h3 className="card-title h4 mb-1">Price vs model year</h3>
+              <p className="text-muted extra-small mb-0">
+                Each dot represents an individual listing; hover to inspect its make and location.
+              </p>
             </div>
             <div className="card-body">
-              <div style={{width:"100%", height:400}}>
+              <div style={{ width: "100%", height: 380 }}>
                 <ResponsiveContainer>
-                  <ScatterChart>
-                    <CartesianGrid />
-                    <XAxis dataKey="x" name="Year" />
-                    <YAxis dataKey="y" name="Price (AED)" />
-                    <Tooltip cursor={{ strokeDasharray: '3 3' }} formatter={(v, n) => [n === "y" ? `AED ${v}` : v, n === "y" ? "Price" : "Year"]} />
-                    <Scatter data={scatterData} />
+                  <ScatterChart margin={{ top: 16, right: 24, bottom: 16, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#cbd5f5" />
+                    <XAxis dataKey="year" name="Model year" tick={{ fontSize: 12 }} />
+                    <YAxis
+                      dataKey="price"
+                      name="Price (AED)"
+                      tickFormatter={(value) => `AED ${Math.round(value / 1000)}k`}
+                    />
+                    <Tooltip
+                      formatter={(value, name) => {
+                        if (name === "price") {
+                          return [formatCurrency(value), "Price"];
+                        }
+                        return [value, "Year"];
+                      }}
+                      labelFormatter={(_, payload) => {
+                        const entry = payload?.[0]?.payload;
+                        if (!entry) return "";
+                        return `${entry.make} · ${entry.city}`;
+                      }}
+                    />
+                    <Scatter data={yearScatterData} fill="#2563eb" />
                   </ScatterChart>
                 </ResponsiveContainer>
               </div>
@@ -69,21 +181,108 @@ export default function Charts({ data }) {
         </div>
       </div>
 
-      <div className="row">
-        <div className="col-12">
-          <div className="card border-0 shadow-sm mb-4">
+      <div className="row g-4">
+        <div className="col-12 col-xl-6">
+          <div className="card border-0 shadow-sm h-100">
             <div className="card-header bg-white border-0 pb-0">
-              <h3 className="card-title h4 mb-0">Average Price by Make (Top 15)</h3>
+              <h3 className="card-title h4 mb-1">Average price by make</h3>
+              <p className="text-muted extra-small mb-0">Top 12 makes with at least 5 active listings.</p>
             </div>
             <div className="card-body">
-              <div style={{width:"100%", height:400}}>
+              <div style={{ width: "100%", height: 360 }}>
                 <ResponsiveContainer>
-                  <BarChart data={byMake}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="make" />
-                    <YAxis />
-                    <Tooltip />
-                    <Bar dataKey="avgPrice" />
+                  <BarChart data={priceByMake} layout="vertical" margin={{ top: 16, right: 24, bottom: 16, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                    <XAxis type="number" tickFormatter={formatCurrency} />
+                    <YAxis type="category" dataKey="make" width={120} tick={{ fontSize: 12 }} />
+                    <Tooltip formatter={(value) => [formatCurrency(value), "Average price"]} />
+                    <Bar dataKey="avgPrice" radius={[0, 8, 8, 0]} fill="#2563eb" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-12 col-xl-6">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-header bg-white border-0 pb-0">
+              <h3 className="card-title h4 mb-1">Price vs mileage</h3>
+              <p className="text-muted extra-small mb-0">Mileage influence on price for vehicles with recorded odometer readings.</p>
+            </div>
+            <div className="card-body">
+              <div style={{ width: "100%", height: 360 }}>
+                <ResponsiveContainer>
+                  <ScatterChart margin={{ top: 16, right: 24, bottom: 16, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#cbd5f5" />
+                    <XAxis
+                      dataKey="kilometers"
+                      name="Mileage (km)"
+                      tickFormatter={(value) => `${Math.round(value / 1000)}k`}
+                    />
+                    <YAxis dataKey="price" name="Price (AED)" tickFormatter={(value) => `AED ${Math.round(value / 1000)}k`} />
+                    <Tooltip
+                      formatter={(value, name) => {
+                        if (name === "price") {
+                          return [formatCurrency(value), "Price"];
+                        }
+                        return [`${Math.round(value / 1000)}k`, "Mileage"];
+                      }}
+                      labelFormatter={(_, payload) => {
+                        const entry = payload?.[0]?.payload;
+                        if (!entry) return "";
+                        return entry.year ? `${entry.make} · ${entry.year}` : entry.make;
+                      }}
+                    />
+                    <Scatter data={mileageScatterData} fill="#f97316" />
+                  </ScatterChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="row g-4">
+        <div className="col-12 col-xl-6">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-header bg-white border-0 pb-0">
+              <h3 className="card-title h4 mb-1">Body type share</h3>
+              <p className="text-muted extra-small mb-0">Share of listings by body configuration.</p>
+            </div>
+            <div className="card-body">
+              <div style={{ width: "100%", height: 320 }}>
+                <ResponsiveContainer>
+                  <PieChart>
+                    <Tooltip formatter={(value, name, { payload }) => [formatPercent(payload.share), name]} />
+                    <Legend verticalAlign="bottom" height={36} />
+                    <Pie data={bodyTypeShare} dataKey="share" nameKey="body" innerRadius={60} outerRadius={110} paddingAngle={4}>
+                      {bodyTypeShare.map((entry, index) => (
+                        <Cell key={entry.body} fill={COLOR_PALETTE[index % COLOR_PALETTE.length]} />
+                      ))}
+                    </Pie>
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-12 col-xl-6">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-header bg-white border-0 pb-0">
+              <h3 className="card-title h4 mb-1">Average market discount by make</h3>
+              <p className="text-muted extra-small mb-0">Shows makes with at least 5 comparable listings.</p>
+            </div>
+            <div className="card-body">
+              <div style={{ width: "100%", height: 320 }}>
+                <ResponsiveContainer>
+                  <BarChart data={discountByMake} layout="vertical" margin={{ top: 16, right: 24, bottom: 16, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                    <XAxis type="number" tickFormatter={formatPercent} />
+                    <YAxis type="category" dataKey="make" width={130} tick={{ fontSize: 12 }} />
+                    <Tooltip formatter={(value) => [formatPercent(value), "Avg discount"]} />
+                    <Bar dataKey="avgDiscount" radius={[0, 8, 8, 0]} fill="#10b981" />
                   </BarChart>
                 </ResponsiveContainer>
               </div>
@@ -92,34 +291,53 @@ export default function Charts({ data }) {
         </div>
       </div>
 
-      <div className="row">
+      <div className="row g-4">
         <div className="col-12">
-          <div className="card border-0 shadow-sm">
+          <div className="card border-0 shadow-sm h-100">
             <div className="card-header bg-white border-0 pb-0">
-              <h3 className="card-title h4 mb-0">Average Price Over Time (by day)</h3>
+              <h3 className="card-title h4 mb-1">Price and volume over time</h3>
+              <p className="text-muted extra-small mb-0">Daily trend combining the average asking price with listing volume.</p>
             </div>
             <div className="card-body">
-              <div style={{width:"100%", height:400}}>
+              <div style={{ width: "100%", height: 380 }}>
                 <ResponsiveContainer>
-                  <LineChart data={byDate}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="date" />
-                    <YAxis />
-                    <Tooltip />
-                    <Line dataKey="avgPrice" dot={false} />
-                    {/* highlight the most recent day's point */}
-                    {latestPoint.length > 0 && (
-                      <Scatter data={latestPoint} />
-                    )}
-                  </LineChart>
+                  <ComposedChart data={priceVolumeByDate} margin={{ top: 16, right: 24, bottom: 16, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                    <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+                    <YAxis yAxisId="left" tickFormatter={(value) => `AED ${Math.round(value / 1000)}k`} />
+                    <YAxis yAxisId="right" orientation="right" tickFormatter={(value) => value.toLocaleString()} />
+                    <Tooltip
+                      formatter={(value, name) => {
+                        if (name === "avgPrice") {
+                          return [formatCurrency(value), "Average price"];
+                        }
+                        return [value.toLocaleString(), "Listings"];
+                      }}
+                    />
+                    <Area
+                      yAxisId="right"
+                      type="monotone"
+                      dataKey="count"
+                      name="Listings"
+                      fill="rgba(37, 99, 235, 0.15)"
+                      stroke="#93c5fd"
+                    />
+                    <Line
+                      yAxisId="left"
+                      type="monotone"
+                      dataKey="avgPrice"
+                      stroke="#2563eb"
+                      strokeWidth={2}
+                      dot={false}
+                      name="Average price"
+                    />
+                  </ComposedChart>
                 </ResponsiveContainer>
               </div>
-              {latestDate && (
-                <div className="text-center mt-3">
-                  <span className="badge bg-warning text-dark fs-6">
-                    Highlighted latest day: <strong>{latestDate}</strong>
-                  </span>
-                </div>
+              {latestSnapshot && (
+                <p className="text-muted extra-small mb-0 mt-3">
+                  Latest day {latestSnapshot.date}: {formatCurrency(latestSnapshot.avgPrice)} across {latestSnapshot.count.toLocaleString()} listings.
+                </p>
               )}
             </div>
           </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -70,61 +70,204 @@ header {
   border-radius: 0;
 }
 
-.app-header__grid {
-  display: grid;
+.app-header {
+  --app-header-height: 72px;
+}
+
+.app-header__mini-stats {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.app-header__mini-stats div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.app-root {
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell {
+  flex: 1;
+  display: flex;
+  position: relative;
+  min-height: 0;
+}
+
+.app-shell--sidebar-open {
+  overflow: hidden;
+}
+
+.app-sidebar__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  border: none;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 1030;
+}
+
+.app-sidebar__backdrop.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.app-sidebar {
+  background: var(--bg);
+  border-right: 1px solid var(--border-light);
+  width: min(320px, 100%);
+  flex: 0 0 auto;
+  position: fixed;
+  top: var(--app-header-height, 72px);
+  bottom: 0;
+  left: 0;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 1040;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-sidebar--open {
+  transform: translateX(0);
+}
+
+.app-sidebar__inner {
+  padding: 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-sidebar__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.app-sidebar__section--header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
 }
 
-.app-header__brand h1 {
-  font-size: 1.25rem;
+.app-sidebar__section-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin: 0;
 }
 
-.app-header__stats {
+.app-sidebar__stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 0.75rem;
+}
+
+.app-sidebar__stats div {
+  background: var(--bg-secondary);
+  border-radius: var(--radius);
   padding: 0.75rem;
   border: 1px solid var(--border-light);
-  border-radius: var(--radius);
-  background: var(--bg-secondary);
 }
 
-.app-header__stat-value {
-  display: block;
-  font-weight: 700;
-  font-size: 1.05rem;
-  line-height: 1.2;
-}
-
-.app-header__stat-label {
-  display: block;
+.app-sidebar__stats dt {
   font-size: 0.75rem;
+  color: var(--muted);
+  margin-bottom: 0.25rem;
+}
+
+.app-sidebar__stats dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.app-sidebar__filters {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.app-sidebar__filters .form-label {
+  font-weight: 500;
   color: var(--muted);
 }
 
-.app-header__search {
-  display: flex;
-  flex-direction: column;
+.app-sidebar__nav {
+  display: grid;
   gap: 0.5rem;
 }
 
-.app-header__filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+.app-sidebar__nav-link {
+  display: inline-flex;
   align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  color: var(--text-light);
+  text-decoration: none;
+  font-weight: 500;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
-.app-header__date-filter {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
+.app-sidebar__nav-link:hover,
+.app-sidebar__nav-link:focus-visible {
+  background: var(--bg-secondary);
+  border-color: var(--border-light);
+  color: var(--text);
 }
 
-.app-header__nav {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+.app-sidebar__nav-link.active {
+  background: rgba(37, 99, 235, 0.12);
+  border-color: rgba(37, 99, 235, 0.32);
+  color: var(--primary);
+}
+
+.app-main {
+  flex: 1;
+  min-width: 0;
+  margin-left: 0;
+}
+
+.app-main__inner {
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+@media (min-width: 992px) {
+  .app-sidebar__backdrop {
+    display: none;
+  }
+
+  .app-sidebar {
+    position: sticky;
+    transform: none;
+    height: calc(100vh - var(--app-header-height, 72px));
+    width: min(320px, 25vw);
+  }
+
+  .app-shell {
+    gap: 0;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .app-sidebar__inner {
+    padding-bottom: 2rem;
+  }
 }
 
 .search-multiselect {
@@ -295,26 +438,6 @@ header {
   white-space: nowrap;
 }
 
-@media (max-width: 575.98px) {
-  .app-header__filters {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .app-header__date-filter {
-    width: 100%;
-  }
-
-  .app-header__nav {
-    justify-content: flex-start;
-    overflow-x: auto;
-  }
-
-  .app-header__nav .btn {
-    flex: 0 0 auto;
-  }
-}
-
 .analytics-layout {
   display: flex;
   flex-direction: column;
@@ -395,6 +518,27 @@ header {
 
 .analytics-kpis .card {
   border-radius: var(--radius-lg);
+}
+
+.analytics-widget .form-label-sm {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.analytics-widget__chart {
+  background: var(--bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  padding: 1rem;
+}
+
+.analytics-widget__chart .recharts-wrapper {
+  margin: 0 auto;
+}
+
+.analytics-widget__chart p {
+  margin-bottom: 0;
 }
 
 @media (max-width: 767.98px) {

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom/vitest';
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof window !== "undefined" && !window.ResizeObserver) {
+  window.ResizeObserver = ResizeObserverStub;
+}
+
+if (typeof global !== "undefined" && !global.ResizeObserver) {
+  global.ResizeObserver = ResizeObserverStub;
+}


### PR DESCRIPTION
## Summary
- replace the header-driven layout with a sidebar navigation and filtering experience
- expand the analytics workspace with configurable metric, table, and chart widgets plus new tests
- enhance the charts page with additional visualisations, a favicon, and updated documentation

## Testing
- `npm run test -- --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_e_68e9dce5cf008332af405a453f5c03d5