### PR TITLE
Add depreciation insights and PDF report builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A modern, responsive web application for analyzing used car listings with real-t
 - **📍 Location Intelligence**: City-based filtering and analysis
 - **🧭 Adaptive Sidebar Workspace**: Minimal header paired with a persistent sidebar for search, filters, and quick navigation
 - **🧮 Analytics Workspace**: Redesigned insight builder supporting metrics, summary tables, and charts with per-widget filters
+- **📄 Export-ready Reports**: Build branded PDF summaries tailored to specific audiences in just a few clicks
 
 ## 🚀 Quick Start
 
@@ -109,12 +110,17 @@ The application expects JSON data with the following structure:
 - **Quick Access**: Click any row to jump straight to the live listing (opens in new tab)
 
 ### Charts Page
-- **Price vs model year**: Scatter plot revealing depreciation patterns by manufacturer and city
-- **Price vs mileage**: Mileage-to-price correlation with tooltips for make and model year context
+- **Top depreciating brands**: Interactive leaderboard that reveals the models losing value fastest for each brand
+- **Top value-retaining brands**: Highlights the marques that hold their price the best with clickable model insights
 - **Average price by make**: Horizontal ranking of the most premium brands filtered by active dataset
 - **Body type distribution**: Pie chart highlighting segment share across sedans, SUVs, hatchbacks, and more
 - **Market discount by make**: Horizontal bars surfacing where listings sit below market averages
 - **Price & volume over time**: Dual-axis view combining average price with daily listing volume
+
+### Reports Page
+- **Guided configuration**: Choose a focus city, timeframe, and which insights to include in the generated dossier
+- **Real-time preview**: Beautiful report preview with highlight metrics, demand pulses, body style mix, and analyst notes
+- **One-click export**: Download a polished PDF branded to your title and audience, perfect for stakeholders or clients
 
 ## 🏗️ Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@elastic/elasticsearch": "^9.1.1",
         "cheerio": "^1.1.2",
+        "jspdf": "^2.5.1",
         "node-fetch": "^3.3.2",
         "p-limit": "^7.1.1",
         "react": "^18.3.1",
@@ -1469,6 +1470,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1692,6 +1700,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.13",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.13.tgz",
@@ -1741,6 +1771,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1785,6 +1827,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -1961,6 +2023,28 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
+      "integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -2266,6 +2350,13 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -2483,6 +2574,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
     "node_modules/find-replace": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
@@ -2689,6 +2786,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
@@ -2860,6 +2971,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/lodash": {
@@ -3132,6 +3261,13 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3227,6 +3363,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/react": {
@@ -3370,6 +3516,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.52.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
@@ -3492,6 +3655,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -3523,6 +3696,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -3540,6 +3723,16 @@
       },
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -3692,6 +3885,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/victory-vendor": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@elastic/elasticsearch": "^9.1.1",
     "cheerio": "^1.1.2",
+    "jspdf": "^2.5.1",
     "node-fetch": "^3.3.2",
     "p-limit": "^7.1.1",
     "react": "^18.3.1",
@@ -26,7 +27,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@vitejs/plugin-react": "^4.3.1",
     "jsdom": "^25.0.0",
-    "vitest": "^2.1.3",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "vitest": "^2.1.3"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Charts from "./pages/Charts.jsx";
 import CarDetail from "./pages/CarDetail.jsx";
 import Flippers from "./pages/Flippers.jsx";
 import Analytics from "./pages/Analytics.jsx";
+import ReportBuilder from "./pages/ReportBuilder.jsx";
 import { num, normalizeTimestamp, deriveBrand, deriveModel, deriveFullLocation, hash32 } from "./utils";
 
 const R2_URL =
@@ -587,6 +588,14 @@ export default function App() {
                 >
                   🧮 Analytics
                 </NavLink>
+                <NavLink
+                  to="/reports"
+                  className={({ isActive }) =>
+                    `app-sidebar__nav-link ${isActive ? "active" : ""}`
+                  }
+                >
+                  📄 Reports
+                </NavLink>
               </div>
             </nav>
           </div>
@@ -607,6 +616,7 @@ export default function App() {
               <Route path="/charts" element={<Charts data={filteredData} />} />
               <Route path="/flippers" element={<Flippers data={filteredData} dateWindow={dateFilterMeta} />} />
               <Route path="/analytics" element={<Analytics data={filteredData} />} />
+              <Route path="/reports" element={<ReportBuilder data={filteredData} />} />
               <Route path="/car/:id" element={<CarDetail data={data} />} />
             </Routes>
           </div>

--- a/src/pages/Charts.jsx
+++ b/src/pages/Charts.jsx
@@ -1,8 +1,6 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   ResponsiveContainer,
-  ScatterChart,
-  Scatter,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -17,7 +15,7 @@ import {
   Legend,
   ComposedChart
 } from "recharts";
-import { groupBy, safeAvg } from "../utils";
+import { deriveBrand, deriveModel, groupBy, safeAvg } from "../utils";
 
 const COLOR_PALETTE = [
   "#2563eb",
@@ -32,30 +30,143 @@ const COLOR_PALETTE = [
   "#14b8a6"
 ];
 
+const clampPercent = (value) => {
+  if (!Number.isFinite(value)) return null;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+};
+
+const formatPercentText = (value) => {
+  if (!Number.isFinite(value)) return "–";
+  return `${value.toFixed(1)}%`;
+};
+
+const linearRegression = (points) => {
+  if (!Array.isArray(points) || points.length < 2) return null;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (const { x, y } of points) {
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const denom = points.length * sumXX - sumX * sumX;
+  if (Math.abs(denom) < 1e-6) return null;
+  const slope = (points.length * sumXY - sumX * sumY) / denom;
+  const intercept = (sumY - slope * sumX) / points.length;
+  if (!Number.isFinite(slope) || !Number.isFinite(intercept)) return null;
+  return { slope, intercept };
+};
+
+const computePercentLoss = ({ slope, intercept }) => {
+  if (!Number.isFinite(slope) || !Number.isFinite(intercept) || intercept <= 0) return null;
+  const percent = (-slope / intercept) * 100;
+  if (!Number.isFinite(percent)) return null;
+  return percent;
+};
+
 export default function Charts({ data }) {
   const totalListings = data.length;
 
-  const yearScatterData = useMemo(() => {
-    return data
-      .filter((row) => Number.isFinite(row.price) && Number.isFinite(row.details_year))
-      .map((row) => ({
-        year: Number(row.details_year),
-        price: Number(row.price),
-        make: row.details_make || row.brand || "Unknown",
-        city: row.city_inferred || "Unknown"
-      }));
+  const depreciationStats = useMemo(() => {
+    if (!data.length) {
+      return { most: [], least: [], brandModels: new Map() };
+    }
+    const nowYear = new Date().getFullYear();
+    const normalized = data
+      .map((row) => {
+        const price = Number(row.price);
+        const year = Number(row.details_year);
+        const brand = deriveBrand(row) || row.details_make || row.brand || "";
+        const model = deriveModel(row) || row.details_model || row.model || "";
+        if (!Number.isFinite(price) || price <= 0) return null;
+        if (!Number.isFinite(year)) return null;
+        const trimmedBrand = brand.trim();
+        const trimmedModel = model.trim();
+        if (!trimmedBrand || !trimmedModel) return null;
+        const cappedYear = Math.max(1980, Math.min(nowYear + 1, year));
+        const age = Math.max(0, Math.min(30, nowYear - cappedYear));
+        return { brand: trimmedBrand, model: trimmedModel, price, age };
+      })
+      .filter(Boolean);
+
+    const groupedByBrand = groupBy(normalized, (item) => item.brand);
+    const brandModels = new Map();
+    const brandEntries = [];
+
+    for (const [brand, items] of Object.entries(groupedByBrand)) {
+      const points = items.map((item) => ({ x: item.age, y: item.price }));
+      if (points.length < 5) continue;
+      const regression = linearRegression(points);
+      if (!regression) continue;
+      const percentLoss = computePercentLoss(regression);
+      if (percentLoss == null) continue;
+      const modelsGrouped = groupBy(items, (item) => item.model);
+      const modelEntries = Object.entries(modelsGrouped)
+        .map(([model, rows]) => {
+          const modelPoints = rows.map((row) => ({ x: row.age, y: row.price }));
+          if (modelPoints.length < 3) return null;
+          const modelRegression = linearRegression(modelPoints);
+          if (!modelRegression) return null;
+          const modelPercentLoss = computePercentLoss(modelRegression);
+          if (modelPercentLoss == null) return null;
+          return {
+            model,
+            sampleCount: modelPoints.length,
+            percentLoss: modelPercentLoss,
+            displayPercent: clampPercent(modelPercentLoss)
+          };
+        })
+        .filter(Boolean);
+
+      if (!modelEntries.length) continue;
+
+      const averagePrice = safeAvg(items.map((item) => item.price)) || 0;
+
+      brandModels.set(brand, {
+        most: [...modelEntries].sort((a, b) => b.percentLoss - a.percentLoss).slice(0, 5),
+        least: [...modelEntries].sort((a, b) => a.percentLoss - b.percentLoss).slice(0, 5)
+      });
+
+      brandEntries.push({
+        brand,
+        sampleCount: points.length,
+        percentLoss,
+        displayPercent: clampPercent(percentLoss),
+        averagePrice
+      });
+    }
+
+    const most = [...brandEntries].sort((a, b) => b.percentLoss - a.percentLoss).slice(0, 5);
+    const least = [...brandEntries].sort((a, b) => a.percentLoss - b.percentLoss).slice(0, 5);
+
+    return { most, least, brandModels };
   }, [data]);
 
-  const mileageScatterData = useMemo(() => {
-    return data
-      .filter((row) => Number.isFinite(row.price) && Number.isFinite(row.details_kilometers))
-      .map((row) => ({
-        kilometers: Number(row.details_kilometers),
-        price: Number(row.price),
-        make: row.details_make || row.brand || "Unknown",
-        year: Number(row.details_year) || null
-      }));
-  }, [data]);
+  const [activeMostBrand, setActiveMostBrand] = useState("");
+  const [activeLeastBrand, setActiveLeastBrand] = useState("");
+
+  useEffect(() => {
+    setActiveMostBrand((current) => {
+      if (current && depreciationStats.most.some((entry) => entry.brand === current)) {
+        return current;
+      }
+      return depreciationStats.most[0]?.brand || "";
+    });
+  }, [depreciationStats.most]);
+
+  useEffect(() => {
+    setActiveLeastBrand((current) => {
+      if (current && depreciationStats.least.some((entry) => entry.brand === current)) {
+        return current;
+      }
+      return depreciationStats.least[0]?.brand || "";
+    });
+  }, [depreciationStats.least]);
 
   const priceByMake = useMemo(() => {
     const rows = data
@@ -135,53 +246,218 @@ export default function Charts({ data }) {
   const latestSnapshot = priceVolumeByDate[priceVolumeByDate.length - 1];
 
   const formatCurrency = (value) => `AED ${Math.round(value ?? 0).toLocaleString("en-US")}`;
-  const formatPercent = (value) => `${(value ?? 0).toFixed(1)}%`;
+  const formatPercent = (value) => `${Number(value ?? 0).toFixed(1)}%`;
+
+  const activeMostBrandMeta = depreciationStats.most.find((entry) => entry.brand === activeMostBrand);
+  const activeLeastBrandMeta = depreciationStats.least.find((entry) => entry.brand === activeLeastBrand);
+  const activeMostModels = depreciationStats.brandModels.get(activeMostBrand)?.most || [];
+  const activeLeastModels = depreciationStats.brandModels.get(activeLeastBrand)?.least || [];
 
   return (
     <div className="container-fluid">
       <div className="row g-4">
-        <div className="col-12">
+        <div className="col-12 col-xl-6">
           <div className="card border-0 shadow-sm h-100">
             <div className="card-header bg-white border-0 pb-0">
-              <h3 className="card-title h4 mb-1">Price vs model year</h3>
+              <h3 className="card-title h4 mb-1">Top 5 most depreciating car brands</h3>
               <p className="text-muted extra-small mb-0">
-                Each dot represents an individual listing; hover to inspect its make and location.
+                Annualised value loss calculated from price vs age regression (min. 5 listings per brand).
               </p>
             </div>
             <div className="card-body">
-              <div style={{ width: "100%", height: 380 }}>
+              <div style={{ width: "100%", height: 260 }}>
                 <ResponsiveContainer>
-                  <ScatterChart margin={{ top: 16, right: 24, bottom: 16, left: 0 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#cbd5f5" />
-                    <XAxis dataKey="year" name="Model year" tick={{ fontSize: 12 }} />
-                    <YAxis
-                      dataKey="price"
-                      name="Price (AED)"
-                      tickFormatter={(value) => `AED ${Math.round(value / 1000)}k`}
-                    />
+                  <BarChart data={depreciationStats.most} layout="vertical" margin={{ top: 8, right: 24, bottom: 8, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                    <XAxis type="number" tickFormatter={formatPercentText} domain={[0, "dataMax"]} />
+                    <YAxis type="category" dataKey="brand" width={130} tick={{ fontSize: 12 }} />
                     <Tooltip
-                      formatter={(value, name) => {
-                        if (name === "price") {
-                          return [formatCurrency(value), "Price"];
-                        }
-                        return [value, "Year"];
-                      }}
-                      labelFormatter={(_, payload) => {
-                        const entry = payload?.[0]?.payload;
-                        if (!entry) return "";
-                        return `${entry.make} · ${entry.city}`;
-                      }}
+                      formatter={(value, _name, payload) => [formatPercentText(value), `${payload?.payload?.sampleCount ?? 0} listings`]}
                     />
-                    <Scatter data={yearScatterData} fill="#2563eb" />
-                  </ScatterChart>
+                    <Bar dataKey="displayPercent" radius={[0, 8, 8, 0]}>
+                      {depreciationStats.most.map((entry) => (
+                        <Cell
+                          key={entry.brand}
+                          cursor="pointer"
+                          fill={entry.brand === activeMostBrand ? "#f43f5e" : "#fecdd3"}
+                          onClick={() => setActiveMostBrand(entry.brand)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
                 </ResponsiveContainer>
+              </div>
+
+              <div className="list-group list-group-flush mt-3">
+                {depreciationStats.most.length === 0 && (
+                  <div className="text-muted extra-small">Not enough data to calculate depreciation trends.</div>
+                )}
+                {depreciationStats.most.map((entry) => (
+                  <button
+                    type="button"
+                    key={entry.brand}
+                    className={`list-group-item list-group-item-action d-flex justify-content-between align-items-center gap-2 ${
+                      entry.brand === activeMostBrand ? "active" : ""
+                    }`}
+                    onClick={() => setActiveMostBrand(entry.brand)}
+                    aria-pressed={entry.brand === activeMostBrand}
+                  >
+                    <div className="text-start">
+                      <div className="fw-semibold">{entry.brand}</div>
+                      <div className="text-muted extra-small">{entry.sampleCount.toLocaleString()} listings · Avg price {formatCurrency(entry.averagePrice)}</div>
+                    </div>
+                    <span className="badge bg-danger-subtle text-danger fw-semibold">
+                      {formatPercent(entry.displayPercent)} / yr
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="mt-3">
+                {activeMostBrandMeta ? (
+                  <div className="p-3 rounded-3 bg-danger-subtle text-danger d-flex flex-column gap-2">
+                    <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                      <div>
+                        <h4 className="h6 mb-1">{activeMostBrandMeta.brand}</h4>
+                        <p className="extra-small mb-0 text-danger">
+                          Losing approximately {formatPercent(activeMostBrandMeta.displayPercent)} of value per year.
+                        </p>
+                      </div>
+                      <span className="badge bg-white text-danger fw-semibold">
+                        {activeMostBrandMeta.sampleCount.toLocaleString()} listings analysed
+                      </span>
+                    </div>
+                    <div>
+                      <h5 className="h6 text-danger mb-2">Most depreciating models</h5>
+                      {activeMostModels.length ? (
+                        <ul className="list-group list-group-flush bg-transparent">
+                          {activeMostModels.map((model) => (
+                            <li
+                              key={`${activeMostBrandMeta.brand}-${model.model}`}
+                              className="list-group-item bg-transparent px-0 d-flex justify-content-between align-items-center gap-3"
+                            >
+                              <div>
+                                <span className="fw-semibold text-danger">{model.model}</span>
+                                <div className="extra-small text-danger opacity-75">{model.sampleCount.toLocaleString()} listings</div>
+                              </div>
+                              <span className="badge bg-danger text-white">{formatPercent(model.displayPercent)} / yr</span>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="extra-small mb-0 text-danger">No model-level insights yet.</p>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-muted extra-small mb-0">Select a brand above to explore model-level depreciation.</p>
+                )}
               </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div className="row g-4">
+        <div className="col-12 col-xl-6">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-header bg-white border-0 pb-0">
+              <h3 className="card-title h4 mb-1">Top 5 least depreciating car brands</h3>
+              <p className="text-muted extra-small mb-0">
+                Brands retaining value best based on annualised loss (min. 5 listings per brand).
+              </p>
+            </div>
+            <div className="card-body">
+              <div style={{ width: "100%", height: 260 }}>
+                <ResponsiveContainer>
+                  <BarChart data={depreciationStats.least} layout="vertical" margin={{ top: 8, right: 24, bottom: 8, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                    <XAxis type="number" tickFormatter={formatPercentText} domain={[0, "dataMax"]} />
+                    <YAxis type="category" dataKey="brand" width={130} tick={{ fontSize: 12 }} />
+                    <Tooltip
+                      formatter={(value, _name, payload) => [formatPercentText(value), `${payload?.payload?.sampleCount ?? 0} listings`]}
+                    />
+                    <Bar dataKey="displayPercent" radius={[0, 8, 8, 0]}>
+                      {depreciationStats.least.map((entry) => (
+                        <Cell
+                          key={entry.brand}
+                          cursor="pointer"
+                          fill={entry.brand === activeLeastBrand ? "#10b981" : "#bbf7d0"}
+                          onClick={() => setActiveLeastBrand(entry.brand)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+
+              <div className="list-group list-group-flush mt-3">
+                {depreciationStats.least.length === 0 && (
+                  <div className="text-muted extra-small">Not enough data to calculate depreciation trends.</div>
+                )}
+                {depreciationStats.least.map((entry) => (
+                  <button
+                    type="button"
+                    key={entry.brand}
+                    className={`list-group-item list-group-item-action d-flex justify-content-between align-items-center gap-2 ${
+                      entry.brand === activeLeastBrand ? "active" : ""
+                    }`}
+                    onClick={() => setActiveLeastBrand(entry.brand)}
+                    aria-pressed={entry.brand === activeLeastBrand}
+                  >
+                    <div className="text-start">
+                      <div className="fw-semibold">{entry.brand}</div>
+                      <div className="text-muted extra-small">{entry.sampleCount.toLocaleString()} listings · Avg price {formatCurrency(entry.averagePrice)}</div>
+                    </div>
+                    <span className="badge bg-success-subtle text-success fw-semibold">
+                      {formatPercent(entry.displayPercent)} / yr
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="mt-3">
+                {activeLeastBrandMeta ? (
+                  <div className="p-3 rounded-3 bg-success-subtle text-success d-flex flex-column gap-2">
+                    <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                      <div>
+                        <h4 className="h6 mb-1">{activeLeastBrandMeta.brand}</h4>
+                        <p className="extra-small mb-0 text-success">
+                          Holding onto value with only {formatPercent(activeLeastBrandMeta.displayPercent)} annual loss.
+                        </p>
+                      </div>
+                      <span className="badge bg-white text-success fw-semibold">
+                        {activeLeastBrandMeta.sampleCount.toLocaleString()} listings analysed
+                      </span>
+                    </div>
+                    <div>
+                      <h5 className="h6 text-success mb-2">Most resilient models</h5>
+                      {activeLeastModels.length ? (
+                        <ul className="list-group list-group-flush bg-transparent">
+                          {activeLeastModels.map((model) => (
+                            <li
+                              key={`${activeLeastBrandMeta.brand}-${model.model}`}
+                              className="list-group-item bg-transparent px-0 d-flex justify-content-between align-items-center gap-3"
+                            >
+                              <div>
+                                <span className="fw-semibold text-success">{model.model}</span>
+                                <div className="extra-small text-success opacity-75">{model.sampleCount.toLocaleString()} listings</div>
+                              </div>
+                              <span className="badge bg-success text-white">{formatPercent(model.displayPercent)} / yr</span>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="extra-small mb-0 text-success">No model-level insights yet.</p>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-muted extra-small mb-0">Select a brand above to explore model-level retention.</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div className="col-12 col-xl-6">
           <div className="card border-0 shadow-sm h-100">
             <div className="card-header bg-white border-0 pb-0">
@@ -198,44 +474,6 @@ export default function Charts({ data }) {
                     <Tooltip formatter={(value) => [formatCurrency(value), "Average price"]} />
                     <Bar dataKey="avgPrice" radius={[0, 8, 8, 0]} fill="#2563eb" />
                   </BarChart>
-                </ResponsiveContainer>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="col-12 col-xl-6">
-          <div className="card border-0 shadow-sm h-100">
-            <div className="card-header bg-white border-0 pb-0">
-              <h3 className="card-title h4 mb-1">Price vs mileage</h3>
-              <p className="text-muted extra-small mb-0">Mileage influence on price for vehicles with recorded odometer readings.</p>
-            </div>
-            <div className="card-body">
-              <div style={{ width: "100%", height: 360 }}>
-                <ResponsiveContainer>
-                  <ScatterChart margin={{ top: 16, right: 24, bottom: 16, left: 0 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#cbd5f5" />
-                    <XAxis
-                      dataKey="kilometers"
-                      name="Mileage (km)"
-                      tickFormatter={(value) => `${Math.round(value / 1000)}k`}
-                    />
-                    <YAxis dataKey="price" name="Price (AED)" tickFormatter={(value) => `AED ${Math.round(value / 1000)}k`} />
-                    <Tooltip
-                      formatter={(value, name) => {
-                        if (name === "price") {
-                          return [formatCurrency(value), "Price"];
-                        }
-                        return [`${Math.round(value / 1000)}k`, "Mileage"];
-                      }}
-                      labelFormatter={(_, payload) => {
-                        const entry = payload?.[0]?.payload;
-                        if (!entry) return "";
-                        return entry.year ? `${entry.make} · ${entry.year}` : entry.make;
-                      }}
-                    />
-                    <Scatter data={mileageScatterData} fill="#f97316" />
-                  </ScatterChart>
                 </ResponsiveContainer>
               </div>
             </div>

--- a/src/pages/Charts.test.jsx
+++ b/src/pages/Charts.test.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Charts from "./Charts.jsx";
+
+const buildSampleRow = ({
+  id,
+  make,
+  model,
+  year,
+  price,
+  city = "Dubai"
+}) => ({
+  uid: `${make}-${model}-${year}-${id}`,
+  id: `${make}-${model}-${year}-${id}`,
+  details_make: make,
+  brand: make,
+  details_model: model,
+  model,
+  details_year: year,
+  price,
+  city_inferred: city
+});
+
+const buildSampleData = () => {
+  const entries = [];
+  const addSeries = (make, model, basePrice, depreciation) => {
+    for (let i = 0; i < 5; i += 1) {
+      const year = 2024 - i;
+      const price = Math.round(basePrice - depreciation * i);
+      entries.push(buildSampleRow({ id: i, make, model, year, price }));
+    }
+  };
+
+  addSeries("Alpha", "A1", 42000, 4000);
+  addSeries("Alpha", "A2", 46000, 5200);
+  addSeries("Beta", "B1", 38000, 1200);
+  addSeries("Beta", "B2", 36000, 800);
+  addSeries("Gamma", "G1", 50000, 2500);
+  addSeries("Gamma", "G2", 52000, 2600);
+
+  return entries;
+};
+
+describe("Charts depreciation insights", () => {
+  it("renders depreciation leaderboards", () => {
+    render(<Charts data={buildSampleData()} />);
+
+    expect(screen.getByText(/Top 5 most depreciating car brands/i)).toBeInTheDocument();
+    expect(screen.getByText(/Top 5 least depreciating car brands/i)).toBeInTheDocument();
+  });
+
+  it("reveals model level insights when selecting brands", async () => {
+    const user = userEvent.setup();
+    render(<Charts data={buildSampleData()} />);
+
+    const mostCard = screen.getByText(/Top 5 most depreciating car brands/i).closest(".card");
+    const leastCard = screen.getByText(/Top 5 least depreciating car brands/i).closest(".card");
+
+    expect(mostCard).not.toBeNull();
+    expect(leastCard).not.toBeNull();
+
+    const alphaButton = within(mostCard).getByRole("button", { name: /alpha/i });
+    await user.click(alphaButton);
+
+    expect(within(mostCard).getByText(/Most depreciating models/i)).toBeInTheDocument();
+    expect(within(mostCard).getByText("A1")).toBeInTheDocument();
+    expect(within(mostCard).getByText("A2")).toBeInTheDocument();
+
+    const betaButton = within(leastCard).getByRole("button", { name: /beta/i });
+    await user.click(betaButton);
+
+    expect(within(leastCard).getByText(/Most resilient models/i)).toBeInTheDocument();
+    expect(within(leastCard).getByText("B1")).toBeInTheDocument();
+    expect(within(leastCard).getByText("B2")).toBeInTheDocument();
+  });
+});

--- a/src/pages/ReportBuilder.jsx
+++ b/src/pages/ReportBuilder.jsx
@@ -1,0 +1,517 @@
+import React, { useMemo, useState } from "react";
+import { jsPDF } from "jspdf";
+import { groupBy, safeAvg } from "../utils";
+
+const computeMedian = (values) => {
+  const sorted = values
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value))
+    .sort((a, b) => a - b);
+  if (!sorted.length) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+  }
+  return Math.round(sorted[mid]);
+};
+
+const average = (values) => {
+  const valid = values
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value));
+  if (!valid.length) return null;
+  return valid.reduce((sum, value) => sum + value, 0) / valid.length;
+};
+
+const formatCurrency = (value) => `AED ${Math.round(value ?? 0).toLocaleString("en-US")}`;
+const formatPercent = (value) => `${Number(value ?? 0).toFixed(1)}%`;
+
+const TIMEFRAME_LABELS = {
+  "3m": "Last 3 months",
+  "6m": "Last 6 months",
+  "12m": "Last 12 months",
+  ytd: "Year to date"
+};
+
+const slugify = (value) =>
+  String(value || "report")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "") || "report";
+
+export default function ReportBuilder({ data }) {
+  const [title, setTitle] = useState("Comprehensive Market Intelligence Report");
+  const [preparedFor, setPreparedFor] = useState("");
+  const [focusCity, setFocusCity] = useState("");
+  const [timeframe, setTimeframe] = useState("6m");
+  const [notes, setNotes] = useState("");
+  const [sections, setSections] = useState({
+    snapshot: true,
+    brands: true,
+    body: true,
+    insights: true
+  });
+
+  const generatedAt = useMemo(() => new Date(), []);
+
+  const normalizedData = useMemo(
+    () => data.filter((row) => Number.isFinite(row.price)),
+    [data]
+  );
+
+  const cityOptions = useMemo(
+    () =>
+      [...new Set(normalizedData.map((row) => row.city_inferred).filter(Boolean))].sort(
+        (a, b) => a.localeCompare(b)
+      ),
+    [normalizedData]
+  );
+
+  const scopedData = useMemo(
+    () => (focusCity ? normalizedData.filter((row) => row.city_inferred === focusCity) : normalizedData),
+    [normalizedData, focusCity]
+  );
+
+  const summary = useMemo(() => {
+    const listings = scopedData.length;
+    const avgPrice = safeAvg(scopedData.map((row) => row.price)) || 0;
+    const medianPrice = computeMedian(scopedData.map((row) => row.price));
+    const avgMileage = safeAvg(scopedData.map((row) => row.details_kilometers)) || 0;
+    const avgDiscount = average(scopedData.map((row) => row.market_discount_pct));
+    const cities = new Set(scopedData.map((row) => row.city_inferred).filter(Boolean)).size;
+
+    const brands = Object.entries(groupBy(scopedData, (row) => row.details_make || row.brand || "Unknown"))
+      .map(([brand, rows]) => ({
+        brand,
+        listings: rows.length,
+        avgPrice: safeAvg(rows.map((row) => row.price)) || 0,
+        avgDiscount: average(rows.map((row) => row.market_discount_pct))
+      }))
+      .filter((entry) => entry.brand !== "Unknown")
+      .sort((a, b) => b.listings - a.listings)
+      .slice(0, 5);
+
+    const bodyTypes = Object.entries(groupBy(scopedData, (row) => row.details_body_type || "Unknown"))
+      .map(([body, rows]) => ({
+        body,
+        listings: rows.length,
+        share: listings ? (rows.length / listings) * 100 : 0
+      }))
+      .sort((a, b) => b.listings - a.listings)
+      .slice(0, 5);
+
+    const models = Object.entries(
+      groupBy(scopedData, (row) => `${row.details_make || row.brand || "Unknown"} ${row.details_model || row.model || ""}`.trim())
+    )
+      .map(([label, rows]) => ({
+        label,
+        listings: rows.length,
+        avgPrice: safeAvg(rows.map((row) => row.price)) || 0,
+        avgDiscount: average(rows.map((row) => row.market_discount_pct))
+      }))
+      .filter((entry) => entry.label && entry.label !== "Unknown")
+      .sort((a, b) => b.listings - a.listings)
+      .slice(0, 5);
+
+    const insights = [];
+    if (brands[0]) {
+      insights.push(
+        `${brands[0].brand} leads activity with ${brands[0].listings.toLocaleString()} listings averaging ${formatCurrency(brands[0].avgPrice)}.`
+      );
+    }
+    if (avgDiscount != null) {
+      insights.push(`Average market discount sits at ${formatPercent(avgDiscount)} across the selection.`);
+    }
+    if (models[0]) {
+      insights.push(
+        `${models[0].label} remains a top-of-mind nameplate with ${models[0].listings.toLocaleString()} recent listings.`
+      );
+    }
+    return {
+      listings,
+      avgPrice,
+      medianPrice,
+      avgMileage,
+      avgDiscount,
+      cities,
+      brands,
+      bodyTypes,
+      models,
+      insights
+    };
+  }, [scopedData]);
+
+  const updateSection = (key) => {
+    setSections((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const timeframeLabel = TIMEFRAME_LABELS[timeframe] || TIMEFRAME_LABELS["6m"];
+
+  const handleDownload = () => {
+    if (!scopedData.length) return;
+    const doc = new jsPDF({ unit: "pt", format: "a4" });
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const pageHeight = doc.internal.pageSize.getHeight();
+    const margin = 48;
+
+    doc.setFillColor(37, 99, 235);
+    doc.rect(0, 0, pageWidth, 140, "F");
+    doc.setTextColor(255, 255, 255);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(22);
+    doc.text(title || "Market Intelligence Report", margin, 70, { maxWidth: pageWidth - margin * 2 });
+
+    doc.setFontSize(12);
+    doc.setFont("helvetica", "normal");
+    const preparedLabel = preparedFor ? `Prepared for: ${preparedFor}` : "Prepared for: Internal stakeholders";
+    doc.text(preparedLabel, margin, 96);
+    doc.text(`Generated on: ${generatedAt.toLocaleDateString()}`, margin, 114);
+    doc.text(`Focus: ${focusCity || "All cities"} · ${timeframeLabel}`, margin, 132);
+
+    let cursorY = 170;
+
+    const writeSection = (heading, lines) => {
+      if (!lines.length) return;
+      const headingHeight = 20;
+      const lineHeight = 16;
+      if (cursorY + headingHeight + lines.length * lineHeight > pageHeight - margin) {
+        doc.addPage();
+        cursorY = margin;
+      }
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(14);
+      doc.setTextColor(37, 99, 235);
+      doc.text(heading, margin, cursorY);
+      cursorY += headingHeight;
+      doc.setFont("helvetica", "normal");
+      doc.setFontSize(11);
+      doc.setTextColor(33, 37, 41);
+      lines.forEach((line) => {
+        doc.text(line, margin, cursorY, { maxWidth: pageWidth - margin * 2 });
+        cursorY += lineHeight;
+      });
+      cursorY += 10;
+    };
+
+    if (sections.snapshot) {
+      const snapshotLines = [
+        `Listings analysed: ${summary.listings.toLocaleString()}`,
+        `Average price: ${formatCurrency(summary.avgPrice)} (median ${formatCurrency(summary.medianPrice)})`,
+        `Average mileage: ${summary.avgMileage ? `${Math.round(summary.avgMileage).toLocaleString()} km` : "Not available"}`,
+        summary.avgDiscount != null
+          ? `Average market discount: ${formatPercent(summary.avgDiscount)}`
+          : "Average market discount: Not available",
+        `Cities covered: ${summary.cities}`
+      ];
+      writeSection("Market snapshot", snapshotLines);
+    }
+
+    if (sections.brands && summary.brands.length) {
+      const brandLines = summary.brands.map(
+        (entry) =>
+          `${entry.brand}: ${entry.listings.toLocaleString()} listings · ${formatCurrency(entry.avgPrice)} · ${
+            entry.avgDiscount != null ? formatPercent(entry.avgDiscount) : "No discount data"
+          }`
+      );
+      writeSection("Top performing brands", brandLines);
+    }
+
+    if (sections.body && summary.bodyTypes.length) {
+      const bodyLines = summary.bodyTypes.map(
+        (entry) => `${entry.body}: ${entry.listings.toLocaleString()} listings · ${formatPercent(entry.share)}`
+      );
+      writeSection("Body style distribution", bodyLines);
+    }
+
+    if (sections.insights && summary.insights.length) {
+      writeSection("Strategic insights", summary.insights);
+    }
+
+    if (notes.trim()) {
+      writeSection("Analyst notes", notes.trim().split(/\n+/));
+    }
+
+    doc.save(`${slugify(title)}-${slugify(focusCity || "all")}.pdf`);
+  };
+
+  return (
+    <div className="container-fluid report-builder">
+      <div className="row g-4">
+        <div className="col-12 col-xl-4">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-header bg-white border-0 pb-0">
+              <h2 className="card-title h4 mb-1">Configure report</h2>
+              <p className="text-muted extra-small mb-0">
+                Tailor the narrative, select focal regions, and choose which insights to include before exporting to PDF.
+              </p>
+            </div>
+            <div className="card-body d-flex flex-column gap-3">
+              <div>
+                <label className="form-label" htmlFor="report-title">Report title</label>
+                <input
+                  id="report-title"
+                  type="text"
+                  className="form-control"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  placeholder="Comprehensive Market Intelligence Report"
+                />
+              </div>
+
+              <div>
+                <label className="form-label" htmlFor="report-recipient">Prepared for</label>
+                <input
+                  id="report-recipient"
+                  type="text"
+                  className="form-control"
+                  value={preparedFor}
+                  onChange={(event) => setPreparedFor(event.target.value)}
+                  placeholder="Executive leadership, client, or internal team"
+                />
+              </div>
+
+              <div>
+                <label className="form-label" htmlFor="report-city">Focus city</label>
+                <select
+                  id="report-city"
+                  className="form-select"
+                  value={focusCity}
+                  onChange={(event) => setFocusCity(event.target.value)}
+                >
+                  <option value="">All cities</option>
+                  {cityOptions.map((city) => (
+                    <option key={city} value={city}>
+                      {city}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="form-label" htmlFor="report-timeframe">Time horizon</label>
+                <select
+                  id="report-timeframe"
+                  className="form-select"
+                  value={timeframe}
+                  onChange={(event) => setTimeframe(event.target.value)}
+                >
+                  <option value="3m">Last 3 months</option>
+                  <option value="6m">Last 6 months</option>
+                  <option value="12m">Last 12 months</option>
+                  <option value="ytd">Year to date</option>
+                </select>
+              </div>
+
+              <fieldset className="border rounded-3 p-3">
+                <legend className="float-none w-auto px-2 fs-6">Include sections</legend>
+                <div className="form-check">
+                  <input
+                    id="section-snapshot"
+                    className="form-check-input"
+                    type="checkbox"
+                    checked={sections.snapshot}
+                    onChange={() => updateSection("snapshot")}
+                  />
+                  <label className="form-check-label" htmlFor="section-snapshot">
+                    Market snapshot
+                  </label>
+                </div>
+                <div className="form-check">
+                  <input
+                    id="section-brands"
+                    className="form-check-input"
+                    type="checkbox"
+                    checked={sections.brands}
+                    onChange={() => updateSection("brands")}
+                  />
+                  <label className="form-check-label" htmlFor="section-brands">
+                    Top performing brands
+                  </label>
+                </div>
+                <div className="form-check">
+                  <input
+                    id="section-body"
+                    className="form-check-input"
+                    type="checkbox"
+                    checked={sections.body}
+                    onChange={() => updateSection("body")}
+                  />
+                  <label className="form-check-label" htmlFor="section-body">
+                    Body style distribution
+                  </label>
+                </div>
+                <div className="form-check">
+                  <input
+                    id="section-insights"
+                    className="form-check-input"
+                    type="checkbox"
+                    checked={sections.insights}
+                    onChange={() => updateSection("insights")}
+                  />
+                  <label className="form-check-label" htmlFor="section-insights">
+                    Strategic insights
+                  </label>
+                </div>
+              </fieldset>
+
+              <div>
+                <label className="form-label" htmlFor="report-notes">Analyst notes</label>
+                <textarea
+                  id="report-notes"
+                  className="form-control"
+                  rows={4}
+                  value={notes}
+                  onChange={(event) => setNotes(event.target.value)}
+                  placeholder="Summaries, action items, or recommendations to surface in the PDF."
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-12 col-xl-8">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body d-flex flex-column gap-4">
+              <div className="report-preview__hero text-white rounded-4 p-4 p-lg-5">
+                <div className="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-4">
+                  <div>
+                    <p className="text-uppercase extra-small mb-2 opacity-75">{timeframeLabel}</p>
+                    <h2 className="h3 mb-2">{title || "Comprehensive Market Intelligence Report"}</h2>
+                    <p className="mb-0">
+                      {preparedFor ? `Prepared for ${preparedFor}` : "Internal distribution"} · {focusCity || "All cities"}
+                    </p>
+                  </div>
+                  <div className="report-preview__stat">
+                    <span className="report-preview__stat-value">{summary.listings.toLocaleString()}</span>
+                    <span className="report-preview__stat-label">Listings analysed</span>
+                  </div>
+                </div>
+              </div>
+
+              {!scopedData.length && (
+                <div className="alert alert-warning mb-0" role="status">
+                  No listings match the selected filters. Try switching the focus city or timeframe to populate the report.
+                </div>
+              )}
+
+              {sections.snapshot && scopedData.length > 0 && (
+                <section>
+                  <header className="d-flex justify-content-between align-items-center mb-3">
+                    <h3 className="h5 mb-0">Market snapshot</h3>
+                    <span className="badge bg-primary-subtle text-primary">Overview</span>
+                  </header>
+                  <div className="report-preview__metrics">
+                    <article>
+                      <h4>Average price</h4>
+                      <p>{formatCurrency(summary.avgPrice)}</p>
+                      <span>Median {formatCurrency(summary.medianPrice)}</span>
+                    </article>
+                    <article>
+                      <h4>Average mileage</h4>
+                      <p>
+                        {summary.avgMileage
+                          ? `${Math.round(summary.avgMileage).toLocaleString()} km`
+                          : "Not available"}
+                      </p>
+                      <span>{summary.cities} active cities</span>
+                    </article>
+                    <article>
+                      <h4>Market discount</h4>
+                      <p>{summary.avgDiscount != null ? formatPercent(summary.avgDiscount) : "Not available"}</p>
+                      <span>Based on advertised vs. market price deltas</span>
+                    </article>
+                  </div>
+                </section>
+              )}
+
+              {sections.brands && scopedData.length > 0 && summary.brands.length > 0 && (
+                <section>
+                  <header className="d-flex justify-content-between align-items-center mb-3">
+                    <h3 className="h5 mb-0">Top performing brands</h3>
+                    <span className="badge bg-info-subtle text-info">Demand pulse</span>
+                  </header>
+                  <div className="report-preview__list">
+                    {summary.brands.map((brand) => (
+                      <div key={brand.brand} className="report-preview__list-item">
+                        <div>
+                          <h4 className="h6 mb-1">{brand.brand}</h4>
+                          <p className="mb-0 extra-small text-muted">
+                            {brand.listings.toLocaleString()} listings · {formatCurrency(brand.avgPrice)}
+                          </p>
+                        </div>
+                        <span className="badge bg-primary-subtle text-primary fw-semibold">
+                          {brand.avgDiscount != null ? formatPercent(brand.avgDiscount) : "n/a"}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {sections.body && scopedData.length > 0 && summary.bodyTypes.length > 0 && (
+                <section>
+                  <header className="d-flex justify-content-between align-items-center mb-3">
+                    <h3 className="h5 mb-0">Body style distribution</h3>
+                    <span className="badge bg-warning-subtle text-warning">Mix</span>
+                  </header>
+                  <div className="report-preview__list">
+                    {summary.bodyTypes.map((body) => (
+                      <div key={body.body} className="report-preview__list-item">
+                        <div>
+                          <h4 className="h6 mb-1">{body.body}</h4>
+                          <p className="mb-0 extra-small text-muted">
+                            {body.listings.toLocaleString()} listings
+                          </p>
+                        </div>
+                        <span className="badge bg-warning-subtle text-warning fw-semibold">
+                          {formatPercent(body.share)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {sections.insights && scopedData.length > 0 && summary.insights.length > 0 && (
+                <section>
+                  <header className="d-flex justify-content-between align-items-center mb-3">
+                    <h3 className="h5 mb-0">Strategic insights</h3>
+                    <span className="badge bg-success-subtle text-success">Opportunities</span>
+                  </header>
+                  <ul className="report-preview__insights">
+                    {summary.insights.map((item, index) => (
+                      <li key={`${item}-${index}`}>{item}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {notes.trim() && (
+                <section>
+                  <header className="d-flex justify-content-between align-items-center mb-3">
+                    <h3 className="h5 mb-0">Analyst notes</h3>
+                    <span className="badge bg-secondary-subtle text-secondary">Commentary</span>
+                  </header>
+                  <p className="mb-0 report-preview__notes">{notes}</p>
+                </section>
+              )}
+
+              <div className="d-flex justify-content-end mt-auto">
+                <button
+                  type="button"
+                  className="btn btn-primary btn-lg"
+                  onClick={handleDownload}
+                  disabled={!scopedData.length}
+                >
+                  Download PDF report
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/ReportBuilder.test.jsx
+++ b/src/pages/ReportBuilder.test.jsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi, beforeEach, describe, it, expect } from "vitest";
+import ReportBuilder from "./ReportBuilder.jsx";
+import { jsPDF } from "jspdf";
+
+vi.mock("jspdf", () => {
+  const factory = vi.fn(() => ({
+    setFillColor: vi.fn(),
+    rect: vi.fn(),
+    setTextColor: vi.fn(),
+    setFont: vi.fn(),
+    setFontSize: vi.fn(),
+    text: vi.fn(),
+    addPage: vi.fn(),
+    internal: {
+      pageSize: {
+        getWidth: vi.fn(() => 595.28),
+        getHeight: vi.fn(() => 842)
+      }
+    },
+    save: vi.fn()
+  }));
+  return { jsPDF: factory, default: factory };
+});
+
+const buildRow = ({
+  id,
+  make,
+  model,
+  price,
+  city,
+  body,
+  km,
+  discount
+}) => ({
+  uid: `${make}-${model}-${id}`,
+  details_make: make,
+  brand: make,
+  details_model: model,
+  model,
+  details_year: 2023,
+  price,
+  city_inferred: city,
+  details_body_type: body,
+  details_kilometers: km,
+  market_discount_pct: discount
+});
+
+const sampleData = [
+  buildRow({ id: 1, make: "Alpha", model: "A1", price: 52000, city: "Dubai", body: "SUV", km: 26000, discount: 6 }),
+  buildRow({ id: 2, make: "Alpha", model: "A2", price: 54000, city: "Dubai", body: "Sedan", km: 28000, discount: 7 }),
+  buildRow({ id: 3, make: "Beta", model: "B1", price: 45000, city: "Abu Dhabi", body: "SUV", km: 31000, discount: 4 }),
+  buildRow({ id: 4, make: "Beta", model: "B2", price: 47000, city: "Abu Dhabi", body: "SUV", km: 33000, discount: 3 }),
+  buildRow({ id: 5, make: "Gamma", model: "G1", price: 61000, city: "Dubai", body: "Coupe", km: 18000, discount: 2 })
+];
+
+beforeEach(() => {
+  jsPDF.mockClear();
+});
+
+describe("ReportBuilder", () => {
+  it("renders report preview with snapshot metrics", () => {
+    render(<ReportBuilder data={sampleData} />);
+
+    expect(screen.getByText(/Comprehensive Market Intelligence Report/i)).toBeInTheDocument();
+    const statValue = document.querySelector(".report-preview__stat-value");
+    expect(statValue).not.toBeNull();
+    expect(statValue.textContent).toBe(String(sampleData.length));
+    const metricsSection = document.querySelector(".report-preview__metrics");
+    expect(metricsSection).not.toBeNull();
+    expect(within(metricsSection).getByText(/Average price/i)).toBeInTheDocument();
+    expect(within(metricsSection).getByText(/Market discount/i)).toBeInTheDocument();
+  });
+
+  it("filters summary when focus city changes", async () => {
+    const user = userEvent.setup();
+    render(<ReportBuilder data={sampleData} />);
+
+    const citySelect = screen.getByLabelText(/Focus city/i);
+    await user.selectOptions(citySelect, "Abu Dhabi");
+
+    await waitFor(() => {
+      const valueEl = document.querySelector(".report-preview__stat-value");
+      expect(valueEl).not.toBeNull();
+      expect(valueEl.textContent).toBe("2");
+    });
+
+    const hero = document.querySelector(".report-preview__hero");
+    expect(hero).not.toBeNull();
+    expect(within(hero).getByText(/Abu Dhabi/)).toBeInTheDocument();
+  });
+
+  it("downloads a PDF when requested", async () => {
+    const user = userEvent.setup();
+    render(<ReportBuilder data={sampleData} />);
+
+    const downloadButton = screen.getByRole("button", { name: /download pdf report/i });
+    await user.click(downloadButton);
+
+    expect(jsPDF).toHaveBeenCalled();
+    const instance = jsPDF.mock.results.at(-1).value;
+    expect(instance.save).toHaveBeenCalled();
+  });
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -200,6 +200,149 @@ header {
   gap: 0.75rem;
 }
 
+.report-preview__hero {
+  background: linear-gradient(135deg, rgba(29, 78, 216, 0.95), rgba(30, 64, 175, 0.95));
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+
+.report-preview__hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.35), transparent 55%);
+  pointer-events: none;
+}
+
+.report-preview__hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.report-preview__stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-align: right;
+  gap: 0.35rem;
+}
+
+.report-preview__stat-value {
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.report-preview__stat-label {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+.report-preview__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.report-preview__metrics article {
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-light);
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.report-preview__metrics article h4 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.report-preview__metrics article p {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.report-preview__metrics article span {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.report-preview__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.report-preview__list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-light);
+  padding: 1rem 1.25rem;
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow);
+}
+
+.report-preview__list-item h4 {
+  margin: 0;
+}
+
+.report-preview__list-item p {
+  margin: 0;
+}
+
+.report-preview__insights {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.report-preview__insights li {
+  border-radius: var(--radius-lg);
+  border-left: 4px solid var(--success);
+  padding: 1rem 1.25rem;
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow);
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.report-preview__notes {
+  white-space: pre-line;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-light);
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+  color: var(--text);
+}
+
+@media (max-width: 768px) {
+  .report-preview__stat {
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .report-preview__stat-value {
+    font-size: 2.1rem;
+  }
+}
+
 .app-sidebar__filters .form-label {
   font-weight: 500;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- add interactive depreciation leaderboards on the charts page with clickable brand/model breakdowns
- introduce a configurable report builder view with PDF export, styling polish, and sidebar navigation
- expand automated coverage and docs for the new analytics experiences while wiring in jspdf support

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68efe3f53d84833299b06f1c2ef68fe1