### PR TITLE
Add admin console and improve data ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A modern, responsive web application for analyzing used car listings with real-t
 - **🧭 Adaptive Sidebar Workspace**: Minimal header paired with a persistent sidebar for search, filters, and quick navigation
 - **🧮 Analytics Workspace**: Redesigned insight builder supporting metrics, summary tables, and charts with per-widget filters
 - **📄 Export-ready Reports**: Build branded PDF summaries tailored to specific audiences in just a few clicks
+- **🛠️ Admin Console**: Monitor ingestion freshness, per-source listing counts, and pricing sanity checks at a glance
 
 ## 🚀 Quick Start
 
@@ -41,7 +42,11 @@ A modern, responsive web application for analyzing used car listings with real-t
 3. **Set up environment variables**
    ```bash
    # Create .env file
-   echo "VITE_R2_JSON_URL=https://your-json-url-here" > .env
+   cat <<'ENV' > .env
+   VITE_R2_JSON_URL=https://your-json-url-here
+   # Optional enrichment feed(s)
+   # VITE_CRSWTCH_JSON_URL=https://carswitch-feed.json
+   ENV
    ```
 
 4. **Start development server**
@@ -60,7 +65,8 @@ A modern, responsive web application for analyzing used car listings with real-t
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `VITE_R2_JSON_URL` | URL to your JSON data source | `https://pub-xxx.r2.dev/data/listings.json` |
+| `VITE_R2_JSON_URL` | URL (or comma-separated list) to your primary JSON data source(s) | `https://pub-xxx.r2.dev/data/listings.json` |
+| `VITE_CRSWTCH_JSON_URL` | Optional CarSwitch feed URL(s) for enrichment | `https://example.com/carswitch.json` |
 
 ### Data Format
 
@@ -100,6 +106,12 @@ The application expects JSON data with the following structure:
 - `location_full` is rendered from the richest available location hierarchy (`location_path`, `location_full`, etc.) and falls back to `city_inferred` + `neighbourhood_en` when present.
 - The listings table surfaces `details_make`, `details_model`, `neighbourhood_en`, `details_regional_specs`, and `details_seller_type` directly for clarity.
 
+### Multiple source feeds
+
+- Both `VITE_R2_JSON_URL` and `VITE_CRSWTCH_JSON_URL` accept either a single URL or a comma/newline-delimited list of URLs. Arrays expressed as JSON (`["https://…", "https://…"]`) are also supported.
+- Additional feeds can be injected at runtime with `window.__R2_JSON_URL__` or `window.__CRSWTCH_JSON_URL__` before the app boots.
+- The Admin console surfaces freshness, coverage, and trimmed price averages for each configured source so you can quickly validate ingestion health.
+
 ## 📱 Usage
 
 ### Overview Page
@@ -121,6 +133,11 @@ The application expects JSON data with the following structure:
 - **Guided configuration**: Choose a focus city, timeframe, and which insights to include in the generated dossier
 - **Real-time preview**: Beautiful report preview with highlight metrics, demand pulses, body style mix, and analyst notes
 - **One-click export**: Download a polished PDF branded to your title and audience, perfect for stakeholders or clients
+
+### Admin Console
+- **Feed visibility**: Quickly inspect how many listings arrived per feed and when they were last refreshed
+- **Freshness monitoring**: Human-readable freshness labels and ISO timestamps highlight stale sources immediately
+- **Quality guardrails**: Trimmed averages surface the effective sample size and how many outliers were excluded from pricing calculations
 
 ## 🏗️ Architecture
 
@@ -178,9 +195,13 @@ npm test
 
 ### Testing
 
-- **Unit tests** cover interactive primitives like the intelligent search multi-select.
-- **Integration tests** exercise end-to-end analytics workflows, including widget filters, grouped tables, and chart previews.
+- **Unit tests** cover helpers (including outlier-resistant averages and data loaders) plus interactive primitives like the intelligent search multi-select.
+- **Integration tests** exercise end-to-end analytics workflows, including widget filters, grouped tables, chart previews, and the new admin console experience.
 - Execute the full suite with `npm test`. Use `npm run test:watch` during development for rapid feedback.
+
+### Data quality
+- Listing-level averages now use robust statistical trimming to exclude anomalous prices before computing market benchmarks.
+- The Admin console reports how many outliers were trimmed per source so data issues can be investigated quickly.
 
 ### Code Quality
 - ESLint configuration for code consistency

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,14 +7,19 @@ import CarDetail from "./pages/CarDetail.jsx";
 import Flippers from "./pages/Flippers.jsx";
 import Analytics from "./pages/Analytics.jsx";
 import ReportBuilder from "./pages/ReportBuilder.jsx";
-import { num, normalizeTimestamp, deriveBrand, deriveModel, deriveFullLocation, hash32 } from "./utils";
-
-const R2_URL =
-  import.meta.env.VITE_R2_JSON_URL?.trim() ||
-  (typeof window !== "undefined" && window.__R2_JSON_URL__) ||
-  "";
-
-const CRSWTCH_URL = import.meta.env.VITE_CRSWTCH_JSON_URL?.trim() || "";
+import Admin from "./pages/Admin.jsx";
+import {
+  num,
+  normalizeTimestamp,
+  deriveBrand,
+  deriveModel,
+  deriveFullLocation,
+  hash32,
+  toArray,
+  parseUrlList,
+  computeTrimmedAverage,
+  formatRelativeTime
+} from "./utils";
 
 const SEARCH_FIELDS = [
   "details_make",
@@ -89,16 +94,6 @@ const cleanLabel = (value) => {
     .join(" ");
 };
 
-const toArray = (payload) => {
-  if (Array.isArray(payload)) return payload;
-  if (payload && typeof payload === "object") {
-    for (const key of ["data", "listings", "results", "items", "rows"]) {
-      if (Array.isArray(payload[key])) return payload[key];
-    }
-  }
-  return [];
-};
-
 const normalizeCarswitchRow = (row) => {
   if (!row || typeof row !== "object") return null;
 
@@ -143,6 +138,7 @@ export default function App() {
   const [data, setData] = useState([]);
   const [err, setErr] = useState("");
   const [loading, setLoading] = useState(true);
+  const [sourceSummaries, setSourceSummaries] = useState([]);
   const [searchTokens, setSearchTokens] = useState([]);
   const [cityFilter, setCityFilter] = useState("");
   const [bodyFilter, setBodyFilter] = useState("");
@@ -212,9 +208,24 @@ export default function App() {
   }, [data]);
 
   useEffect(() => {
+    const resolveSourceUrls = (value, windowKey) => {
+      const direct = parseUrlList(value);
+      if (direct.length) return direct;
+      if (typeof window !== "undefined" && windowKey) {
+        return parseUrlList(window[windowKey]);
+      }
+      return [];
+    };
+
     (async () => {
       try {
-        if (!R2_URL) throw new Error("R2 JSON URL not set. Set VITE_R2_JSON_URL or window.__R2_JSON_URL__.");
+        const primaryUrls = resolveSourceUrls(import.meta.env.VITE_R2_JSON_URL, "__R2_JSON_URL__");
+        const carswitchUrls = resolveSourceUrls(import.meta.env.VITE_CRSWTCH_JSON_URL, "__CRSWTCH_JSON_URL__");
+
+        if (!primaryUrls.length) {
+          throw new Error("R2 JSON URL not set. Set VITE_R2_JSON_URL or window.__R2_JSON_URL__.");
+        }
+
         const fetchJson = async (url, { optional = false } = {}) => {
           if (!url) {
             if (optional) return [];
@@ -236,17 +247,49 @@ export default function App() {
           }
         };
 
-        const [primaryPayload, carswitchPayload] = await Promise.all([
-          fetchJson(R2_URL),
-          fetchJson(CRSWTCH_URL, { optional: true })
-        ]);
+        const sourceConfigs = [
+          {
+            key: "primary",
+            label: "Primary feed",
+            urls: primaryUrls,
+            optional: false,
+            normalize: (row) => ({ ...row, source: row?.source || "primary" })
+          },
+          {
+            key: "carswitch",
+            label: "CarSwitch",
+            urls: carswitchUrls,
+            optional: true,
+            normalize: (row) => normalizeCarswitchRow({ ...row, source: row?.source || "carswitch" })
+          }
+        ];
 
-        const baseRows = toArray(primaryPayload);
-        const carswitchRows = toArray(carswitchPayload)
-          .map(normalizeCarswitchRow)
-          .filter(Boolean);
+        const fetchedSources = await Promise.all(
+          sourceConfigs.map(async (config) => {
+            if (!config.urls.length) {
+              return { ...config, rows: [], rawCount: 0 };
+            }
 
-        const rows = [...baseRows, ...carswitchRows];
+            const payloads = await Promise.all(
+              config.urls.map((url) => fetchJson(url, { optional: config.optional }))
+            );
+
+            const rows = [];
+            let rawCount = 0;
+            payloads.forEach((payload) => {
+              const arrayPayload = toArray(payload);
+              rawCount += arrayPayload.length;
+              arrayPayload.forEach((item) => {
+                const normalized = config.normalize ? config.normalize(item) : item;
+                if (normalized) rows.push(normalized);
+              });
+            });
+
+            return { ...config, rows, rawCount };
+          })
+        );
+
+        const rows = fetchedSources.flatMap((entry) => entry.rows).filter(Boolean);
 
         rows.forEach((d) => {
           d.price = num(d.price);
@@ -287,7 +330,7 @@ export default function App() {
         const cutoff = now - threeMonthsMs;
 
         // Build segment aggregates
-        const segMap = new Map(); // key => {sum,count}
+        const segMap = new Map(); // key => prices array
         for (const d of rows) {
           if (!Number.isFinite(d.price)) continue;
           if (!Number.isFinite(d.created_at_epoch_ms) || d.created_at_epoch_ms < cutoff) continue;
@@ -296,10 +339,14 @@ export default function App() {
           const year = d.details_year;
           if (!make || !model || !Number.isFinite(year)) continue;
           const key = `${make}|${model}|${year}`.toLowerCase();
-          const cur = segMap.get(key) || { sum: 0, count: 0 };
-          cur.sum += d.price;
-          cur.count += 1;
-          segMap.set(key, cur);
+          if (!segMap.has(key)) segMap.set(key, []);
+          segMap.get(key).push(d.price);
+        }
+
+        const segStats = new Map();
+        for (const [key, prices] of segMap.entries()) {
+          const { average, count } = computeTrimmedAverage(prices);
+          segStats.set(key, { average, count });
         }
 
         // Apply market_avg & market_diff to each row (diff = market_avg - price)
@@ -311,9 +358,9 @@ export default function App() {
           let market_count = 0;
           if (make && model && Number.isFinite(year)) {
             const key = `${make}|${model}|${year}`.toLowerCase();
-            const agg = segMap.get(key);
-            if (agg && agg.count > 0) {
-              market_avg = Math.round(agg.sum / agg.count);
+            const agg = segStats.get(key);
+            if (agg && agg.count > 0 && Number.isFinite(agg.average)) {
+              market_avg = agg.average;
               market_count = agg.count;
             }
           }
@@ -335,6 +382,73 @@ export default function App() {
         }
 
         setData(rows);
+
+        const now = Date.now();
+        const summaryMap = new Map();
+        for (const source of fetchedSources) {
+          if (!summaryMap.has(source.key)) {
+            summaryMap.set(source.key, {
+              key: source.key,
+              label: source.label,
+              urls: source.urls,
+              listingCount: 0,
+              latestMs: null,
+              earliestMs: null,
+              prices: [],
+              rawCount: source.rawCount || 0
+            });
+          }
+        }
+
+        for (const d of rows) {
+          const key = d.source || "primary";
+          if (!summaryMap.has(key)) {
+            summaryMap.set(key, {
+              key,
+              label: key,
+              urls: [],
+              listingCount: 0,
+              latestMs: null,
+              earliestMs: null,
+              prices: [],
+              rawCount: 0
+            });
+          }
+          const meta = summaryMap.get(key);
+          meta.listingCount += 1;
+          if (Number.isFinite(d.created_at_epoch_ms)) {
+            meta.latestMs = meta.latestMs == null ? d.created_at_epoch_ms : Math.max(meta.latestMs, d.created_at_epoch_ms);
+            meta.earliestMs = meta.earliestMs == null ? d.created_at_epoch_ms : Math.min(meta.earliestMs, d.created_at_epoch_ms);
+          }
+          if (Number.isFinite(d.price)) {
+            meta.prices.push(d.price);
+          }
+        }
+
+        const summaries = Array.from(summaryMap.values()).map((meta) => {
+          const { average, count, removed } = computeTrimmedAverage(meta.prices);
+          const rangeMs =
+            Number.isFinite(meta.latestMs) && Number.isFinite(meta.earliestMs)
+              ? meta.latestMs - meta.earliestMs
+              : null;
+          return {
+            key: meta.key,
+            label: meta.label,
+            urls: meta.urls,
+            listingCount: meta.listingCount,
+            rawCount: meta.rawCount,
+            lastUpdatedMs: meta.latestMs,
+            lastUpdatedIso: meta.latestMs ? new Date(meta.latestMs).toISOString() : "",
+            oldestIso: meta.earliestMs ? new Date(meta.earliestMs).toISOString() : "",
+            averagePrice: Number.isFinite(average) ? average : null,
+            effectiveSample: count,
+            removedOutliers: removed,
+            freshnessLabel: Number.isFinite(meta.latestMs) ? formatRelativeTime(meta.latestMs, now) : "No timestamp",
+            coverageDays: Number.isFinite(rangeMs) ? Math.max(0, Math.round(rangeMs / (24 * 60 * 60 * 1000))) : null
+          };
+        });
+
+        setSourceSummaries(summaries.sort((a, b) => a.label.localeCompare(b.label)));
       } catch (e) {
         setErr(String(e.message || e));
       } finally {
@@ -369,9 +483,8 @@ export default function App() {
 
   const stats = useMemo(() => {
     const totalListings = filteredData.length;
-    const avgPrice = totalListings > 0
-      ? Math.round(filteredData.reduce((sum, d) => sum + (d.price || 0), 0) / totalListings)
-      : 0;
+    const priceStats = computeTrimmedAverage(filteredData.map((d) => d.price));
+    const avgPrice = Number.isFinite(priceStats.average) ? priceStats.average : 0;
     const cities = new Set(filteredData.map((d) => d.city_inferred).filter(Boolean)).size;
     return { totalListings, avgPrice, cities };
   }, [filteredData]);
@@ -596,6 +709,14 @@ export default function App() {
                 >
                   📄 Reports
                 </NavLink>
+                <NavLink
+                  to="/admin"
+                  className={({ isActive }) =>
+                    `app-sidebar__nav-link ${isActive ? "active" : ""}`
+                  }
+                >
+                  🛠️ Admin
+                </NavLink>
               </div>
             </nav>
           </div>
@@ -617,6 +738,7 @@ export default function App() {
               <Route path="/flippers" element={<Flippers data={filteredData} dateWindow={dateFilterMeta} />} />
               <Route path="/analytics" element={<Analytics data={filteredData} />} />
               <Route path="/reports" element={<ReportBuilder data={filteredData} />} />
+              <Route path="/admin" element={<Admin data={data} sources={sourceSummaries} />} />
               <Route path="/car/:id" element={<CarDetail data={data} />} />
             </Routes>
           </div>

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,0 +1,138 @@
+import React, { useMemo } from "react";
+import { fmtPrice, esc } from "../utils";
+
+const formatCoverage = (days) => {
+  if (!Number.isFinite(days)) return "—";
+  if (days <= 0) return "< 1 day";
+  if (days === 1) return "1 day";
+  if (days < 14) return `${days} days`;
+  const weeks = Math.round(days / 7);
+  if (weeks < 8) return `${weeks} wk${weeks === 1 ? "" : "s"}`;
+  const months = Math.round(days / 30);
+  return `${months} mo`;
+};
+
+export default function Admin({ data = [], sources = [] }) {
+  const summary = useMemo(() => {
+    const uniqueSources = new Set(data.map((row) => row?.source || "primary"));
+    const totalListings = data.length;
+    const totalRemoved = sources.reduce((acc, src) => acc + (src.removedOutliers || 0), 0);
+    return {
+      totalListings,
+      uniqueSources: uniqueSources.size,
+      totalRemoved,
+      loadedSources: sources.length
+    };
+  }, [data, sources]);
+
+  return (
+    <div className="container-fluid">
+      <div className="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+        <div>
+          <h2 className="h4 mb-1">Data Sources Console</h2>
+          <p className="text-muted mb-0">Monitor feed freshness, record counts, and pricing sanity checks.</p>
+        </div>
+      </div>
+
+      <div className="row g-3 mb-4">
+        <div className="col-12 col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <div className="text-muted text-uppercase extra-small mb-1">Active listings</div>
+              <div className="h4 mb-0">{summary.totalListings.toLocaleString()}</div>
+            </div>
+          </div>
+        </div>
+        <div className="col-12 col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <div className="text-muted text-uppercase extra-small mb-1">Sources loaded</div>
+              <div className="h4 mb-0">{summary.loadedSources}</div>
+              <div className="text-muted small">{summary.uniqueSources} with listings</div>
+            </div>
+          </div>
+        </div>
+        <div className="col-12 col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <div className="text-muted text-uppercase extra-small mb-1">Outliers trimmed</div>
+              <div className="h4 mb-0">{summary.totalRemoved.toLocaleString()}</div>
+              <div className="text-muted small">Excluded from pricing averages</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card border-0 shadow-sm">
+        <div className="card-body p-0">
+          {sources.length === 0 ? (
+            <div className="p-4 text-center text-muted">No source metadata available yet.</div>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-striped table-hover mb-0" aria-label="Data source overview">
+                <thead className="table-light">
+                  <tr>
+                    <th scope="col">Source</th>
+                    <th scope="col">Listings</th>
+                    <th scope="col">Trimmed avg price</th>
+                    <th scope="col">Freshest update</th>
+                    <th scope="col">Coverage window</th>
+                    <th scope="col">Data endpoints</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sources.map((src) => (
+                    <tr key={src.key}>
+                      <th scope="row">{esc(src.label || src.key)}</th>
+                      <td>
+                        <div className="fw-semibold">{src.listingCount.toLocaleString()}</div>
+                        <div className="text-muted small">
+                          Raw: {Number.isFinite(src.rawCount) ? src.rawCount.toLocaleString() : "0"}
+                        </div>
+                      </td>
+                      <td>
+                        <div className="fw-semibold">
+                          {Number.isFinite(src.averagePrice) ? fmtPrice(src.averagePrice) : "N/A"}
+                        </div>
+                        <div className="text-muted small">
+                          {src.effectiveSample ?? 0} samples · {src.removedOutliers ?? 0} outliers
+                        </div>
+                      </td>
+                      <td>
+                        <div className="fw-semibold">{src.freshnessLabel || "—"}</div>
+                        {src.lastUpdatedIso && (
+                          <div className="text-muted small">{new Date(src.lastUpdatedIso).toLocaleString()}</div>
+                        )}
+                      </td>
+                      <td>
+                        <div className="fw-semibold">{formatCoverage(src.coverageDays)}</div>
+                        {src.oldestIso && (
+                          <div className="text-muted small">From {new Date(src.oldestIso).toLocaleDateString()}</div>
+                        )}
+                      </td>
+                      <td>
+                        {src.urls && src.urls.length ? (
+                          <ul className="list-unstyled mb-0 text-break">
+                            {src.urls.map((url) => (
+                              <li key={url} className="small">
+                                <a href={url} target="_blank" rel="noreferrer" className="link-primary">
+                                  {url}
+                                </a>
+                              </li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <span className="text-muted small">No URL configured</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Admin.test.jsx
+++ b/src/pages/Admin.test.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import Admin from "./Admin.jsx";
+
+describe("Admin page", () => {
+  const sampleSources = [
+    {
+      key: "primary",
+      label: "Primary feed",
+      listingCount: 120,
+      rawCount: 130,
+      averagePrice: 150000,
+      effectiveSample: 110,
+      removedOutliers: 5,
+      freshnessLabel: "3 hr ago",
+      lastUpdatedIso: "2024-02-20T10:00:00.000Z",
+      coverageDays: 14,
+      oldestIso: "2024-02-06T10:00:00.000Z",
+      urls: ["https://example.com/primary.json"]
+    }
+  ];
+
+  const sampleData = Array.from({ length: 120 }, (_, idx) => ({
+    id: idx,
+    source: "primary"
+  }));
+
+  it("renders summary cards and table rows", () => {
+    render(<Admin data={sampleData} sources={sampleSources} />);
+
+    const listingsCard = screen.getByText(/active listings/i).closest(".card-body");
+    expect(listingsCard).not.toBeNull();
+    expect(within(listingsCard).getByText("120")).toBeInTheDocument();
+
+    const table = screen.getByRole("table", { name: /data source overview/i });
+    const rows = within(table).getAllByRole("row");
+    expect(rows).toHaveLength(2); // header + 1 data row
+    expect(within(rows[1]).getByRole("rowheader", { name: /primary feed/i })).toBeInTheDocument();
+    expect(within(rows[1]).getByText(/3 hr ago/)).toBeInTheDocument();
+    expect(within(rows[1]).getByText(/AED 150,000/)).toBeInTheDocument();
+  });
+
+  it("shows placeholder when no sources provided", () => {
+    render(<Admin data={[]} sources={[]} />);
+    expect(screen.getByText(/no source metadata available/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/Flippers.jsx
+++ b/src/pages/Flippers.jsx
@@ -55,7 +55,7 @@ export default function Flippers({ data, dateWindow }) {
       <div className="card border-0 shadow-sm">
         <div className="card-body p-0">
           <div className="table-responsive" style={{ overflowX: "auto" }}>
-            <table className="table table-hover table-striped mb-0 text-nowrap align-middle" style={{ minWidth: "1150px" }}>
+            <table className="table table-hover table-striped mb-0 text-nowrap align-middle" style={{ minWidth: "1080px" }}>
               <thead className="table-light">
                 <tr>
                   <th>When</th>
@@ -63,7 +63,6 @@ export default function Flippers({ data, dateWindow }) {
                   <th>Model</th>
                   <th>Year</th>
                   <th>Price</th>
-                  <th>Market Discount</th>
                   <th>Discount %</th>
                   <th>Location</th>
                   <th>Seller Type</th>
@@ -84,8 +83,12 @@ export default function Flippers({ data, dateWindow }) {
                         <div className="small text-muted">Avg: {fmtPrice(d.market_avg)}</div>
                       )}
                     </td>
-                    <td className="fw-bold text-success">{Number.isFinite(d.market_diff) ? fmtPrice(d.market_diff) : 'N/A'}</td>
-                    <td className="fw-bold text-success">{formatPercent(d.market_discount_pct)}</td>
+                    <td className="fw-bold text-success">
+                      <div>{formatPercent(d.market_discount_pct)}</div>
+                      {Number.isFinite(d.market_diff) && (
+                        <div className="text-muted small">{fmtPrice(d.market_diff)} vs. market</div>
+                      )}
+                    </td>
                     <td className="text-info">{esc(d.location_full || d.city_inferred || '')}</td>
                     <td>{esc(d.details_seller_type || '')}</td>
                     <td>{esc(d.details_regional_specs || '')}</td>

--- a/src/pages/Flippers.test.jsx
+++ b/src/pages/Flippers.test.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Flippers from "./Flippers.jsx";
+
+const buildRow = () => ({
+  uid: "abc",
+  created_at_epoch_ms: Date.now(),
+  details_make: "Toyota",
+  brand: "Toyota",
+  details_model: "Land Cruiser",
+  model: "Land Cruiser",
+  details_year: 2022,
+  price: 320000,
+  market_avg: 360000,
+  market_diff: 40000,
+  market_discount_pct: (40000 / 360000) * 100,
+  location_full: "Dubai",
+  details_seller_type: "Dealer",
+  details_regional_specs: "GCC",
+});
+
+describe("Flippers page", () => {
+  it("renders discount percent with inline market delta", () => {
+    const dateWindow = { label: "last 7 days", cutoffMs: Date.now() - 7 * 24 * 60 * 60 * 1000 };
+    render(
+      <MemoryRouter>
+        <Flippers data={[buildRow()]} dateWindow={dateWindow} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/market discount/i)).not.toBeInTheDocument();
+
+    const discountCell = screen.getByText(/11\.1%/i).closest("td");
+    expect(discountCell).not.toBeNull();
+    expect(within(discountCell).getByText(/AED 40,000/i)).toBeInTheDocument();
+  });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,175 @@ export const num = (v) => {
   return Number.isFinite(n) ? n : null;
 };
 
+const normalizeToList = (value) => {
+  if (!value && value !== 0) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === "string" ? entry.trim() : String(entry)))
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    if ((trimmed.startsWith("[") && trimmed.endsWith("]")) || trimmed.startsWith("{")) {
+      try {
+        return normalizeToList(JSON.parse(trimmed));
+      } catch (error) {
+        console.warn("Failed to parse JSON list", error);
+      }
+    }
+    return trimmed
+      .split(/[\n,]+/)
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "object") {
+    return normalizeToList(Object.values(value || {}));
+  }
+  return [String(value)].filter(Boolean);
+};
+
+export const parseUrlList = (value, { allowWindowLookup = false, windowKey } = {}) => {
+  if (allowWindowLookup && !value && typeof window !== "undefined" && windowKey) {
+    return parseUrlList(window[windowKey]);
+  }
+  return normalizeToList(value);
+};
+
+const candidateArrayKeys = [
+  "data",
+  "listings",
+  "results",
+  "items",
+  "rows",
+  "cars",
+  "vehicles",
+  "entries",
+  "records",
+  "payload",
+  "response",
+  "dataset"
+];
+
+const findFirstArray = (value, depth = 0) => {
+  if (!value || depth > 3) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "object") return [];
+
+  for (const key of candidateArrayKeys) {
+    if (Array.isArray(value[key])) {
+      return value[key];
+    }
+  }
+
+  for (const key of candidateArrayKeys) {
+    if (value[key] && typeof value[key] === "object") {
+      const nested = findFirstArray(value[key], depth + 1);
+      if (nested.length) return nested;
+    }
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    if (Array.isArray(nestedValue)) return nestedValue;
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    if (nestedValue && typeof nestedValue === "object") {
+      const nested = findFirstArray(nestedValue, depth + 1);
+      if (nested.length) return nested;
+    }
+  }
+
+  return [];
+};
+
+export const toArray = (payload) => {
+  if (Array.isArray(payload)) return payload;
+  if (payload && typeof payload === "object") {
+    const direct = findFirstArray(payload);
+    if (direct.length) return direct;
+  }
+  return [];
+};
+
+const quantile = (sortedValues, q) => {
+  const n = sortedValues.length;
+  if (!n) return null;
+  if (n === 1) return sortedValues[0];
+  const pos = (n - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  if (base + 1 < n) {
+    return sortedValues[base] + rest * (sortedValues[base + 1] - sortedValues[base]);
+  }
+  return sortedValues[base];
+};
+
+export const computeTrimmedAverage = (values, { iqrFactor = 1.5, maxStdDevs = 3 } = {}) => {
+  const valid = values.filter((v) => Number.isFinite(v));
+  if (!valid.length) return { average: null, count: 0, removed: 0 };
+  const sorted = valid.slice().sort((a, b) => a - b);
+
+  let lower = sorted[0];
+  let upper = sorted[sorted.length - 1];
+  const q1 = quantile(sorted, 0.25);
+  const q3 = quantile(sorted, 0.75);
+  const iqr = q3 != null && q1 != null ? q3 - q1 : null;
+
+  if (Number.isFinite(iqr) && iqr > 0) {
+    lower = q1 - iqrFactor * iqr;
+    upper = q3 + iqrFactor * iqr;
+  } else {
+    const median = quantile(sorted, 0.5) ?? sorted[Math.floor(sorted.length / 2)];
+    const deviations = sorted.map((v) => Math.abs(v - median));
+    const mad = quantile(deviations, 0.5);
+    if (mad && mad > 0) {
+      const scale = mad * 1.4826;
+      lower = median - maxStdDevs * scale;
+      upper = median + maxStdDevs * scale;
+    } else {
+      const tolerance = Math.max(500, Math.abs(median) * 0.1);
+      lower = median - tolerance;
+      upper = median + tolerance;
+    }
+  }
+
+  let filtered = sorted.filter((v) => v >= lower && v <= upper);
+  if (!filtered.length) filtered = sorted;
+  const sum = filtered.reduce((acc, v) => acc + v, 0);
+  return {
+    average: Math.round(sum / filtered.length),
+    count: filtered.length,
+    removed: sorted.length - filtered.length
+  };
+};
+
+export const formatRelativeTime = (timestamp, now = Date.now()) => {
+  if (!Number.isFinite(timestamp)) return "No timestamp";
+  const diffMs = now - timestamp;
+  if (diffMs < 0) {
+    const aheadMs = Math.abs(diffMs);
+    const aheadMinutes = Math.round(aheadMs / (60 * 1000));
+    if (aheadMinutes < 60) return `in ${aheadMinutes} min`;
+    const aheadHours = Math.round(aheadMinutes / 60);
+    if (aheadHours < 48) return `in ${aheadHours} hr`;
+    const aheadDays = Math.round(aheadHours / 24);
+    return `in ${aheadDays} days`;
+  }
+  const minutes = Math.round(diffMs / (60 * 1000));
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours} hr ago`;
+  const days = Math.round(hours / 24);
+  if (days < 60) return `${days} days ago`;
+  const months = Math.round(days / 30);
+  if (months < 24) return `${months} mo ago`;
+  const years = Math.round(months / 12);
+  return `${years} yr ago`;
+};
+
 export const cmp = (a, b) => {
   if (a == null && b == null) return 0;
   if (a == null) return 1;

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { computeTrimmedAverage, formatRelativeTime, toArray } from "./utils";
+
+describe("computeTrimmedAverage", () => {
+  it("excludes extreme outliers when computing the mean", () => {
+    const values = [100000, 101000, 99000, 2500000];
+    const result = computeTrimmedAverage(values);
+    expect(result.average).toBe(100000);
+    expect(result.count).toBe(3);
+    expect(result.removed).toBe(1);
+  });
+
+  it("falls back to using all values when distribution is tight", () => {
+    const values = [50000, 50500, 49500];
+    const result = computeTrimmedAverage(values);
+    expect(result.average).toBe(50000);
+    expect(result.count).toBe(3);
+    expect(result.removed).toBe(0);
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("creates a human readable delta", () => {
+    const now = new Date("2024-02-20T00:00:00Z").getTime();
+    const timestamp = new Date("2024-02-19T22:30:00Z").getTime();
+    expect(formatRelativeTime(timestamp, now)).toBe("2 hr ago");
+  });
+
+  it("describes future timestamps", () => {
+    const now = new Date("2024-02-20T00:00:00Z").getTime();
+    const timestamp = new Date("2024-02-20T01:00:00Z").getTime();
+    expect(formatRelativeTime(timestamp, now)).toBe("in 1 hr");
+  });
+});
+
+describe("toArray", () => {
+  it("finds nested arrays in payload objects", () => {
+    const payload = { data: { results: [{ id: 1 }, { id: 2 }] } };
+    expect(toArray(payload)).toHaveLength(2);
+  });
+
+  it("returns an empty array when nothing is found", () => {
+    expect(toArray({ foo: "bar" })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- enhance data ingestion to support multiple source URLs, normalize Carswitch feeds, and compute trimmed market averages
- add an admin console for tracking data sources plus integrate trimmed-average summaries into dashboards
- streamline the flippers table layout and expand documentation and automated test coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4cc38b5c08332895fa97229e13fec