### PR TITLE
Refine secondary feed integration and add regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A modern, responsive web application for analyzing used car listings with real-t
    cat <<'ENV' > .env
    VITE_R2_JSON_URL=https://your-json-url-here
    # Optional enrichment feed(s)
-   # VITE_CRSWTCH_JSON_URL=https://carswitch-feed.json
+   # VITE_SECONDARY_JSON_URL=https://secondary-feed.json
    ENV
    ```
 
@@ -66,7 +66,7 @@ A modern, responsive web application for analyzing used car listings with real-t
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `VITE_R2_JSON_URL` | URL (or comma-separated list) to your primary JSON data source(s) | `https://pub-xxx.r2.dev/data/listings.json` |
-| `VITE_CRSWTCH_JSON_URL` | Optional CarSwitch feed URL(s) for enrichment | `https://example.com/carswitch.json` |
+| `VITE_SECONDARY_JSON_URL` | Optional secondary feed URL(s) for enrichment | `https://example.com/secondary.json` |
 
 ### Data Format
 
@@ -108,8 +108,8 @@ The application expects JSON data with the following structure:
 
 ### Multiple source feeds
 
-- Both `VITE_R2_JSON_URL` and `VITE_CRSWTCH_JSON_URL` accept either a single URL or a comma/newline-delimited list of URLs. Arrays expressed as JSON (`["https://…", "https://…"]`) are also supported.
-- Additional feeds can be injected at runtime with `window.__R2_JSON_URL__` or `window.__CRSWTCH_JSON_URL__` before the app boots.
+- Both `VITE_R2_JSON_URL` and `VITE_SECONDARY_JSON_URL` accept either a single URL or a comma/newline-delimited list of URLs. Arrays expressed as JSON (`["https://…", "https://…"]`) are also supported.
+- Additional feeds can be injected at runtime with `window.__R2_JSON_URL__` or `window.__SECONDARY_JSON_URL__` before the app boots.
 - The Admin console surfaces freshness, coverage, and trimmed price averages for each configured source so you can quickly validate ingestion health.
 
 ## 📱 Usage

--- a/src/App.integration.test.jsx
+++ b/src/App.integration.test.jsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import App from "./App.jsx";
+
+describe("App integration", () => {
+  const fixedNow = new Date("2024-05-01T00:00:00Z").getTime();
+
+  beforeEach(() => {
+    vi.stubEnv("VITE_R2_JSON_URL", "[\"https://primary.test/feed.json\"]");
+    vi.stubEnv("VITE_SECONDARY_JSON_URL", "[\"https://secondary.test/feed.json\"]");
+    vi.spyOn(Date, "now").mockReturnValue(fixedNow);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      const primaryPayload = [
+        {
+          id: "primary-1",
+          title_en: "Nissan Altima 2020",
+          price: 98000,
+          city_inferred: "Dubai",
+          details_make: "Nissan",
+          details_model: "Altima",
+          details_body_type: "Sedan",
+          details_year: 2020,
+          created_at_iso: "2024-04-15T00:00:00Z",
+          created_at_epoch_ms: new Date("2024-04-15T00:00:00Z").getTime(),
+        }
+      ];
+
+      const secondaryPayload = [
+        {
+          id: "secondary-1",
+          detail_make: "honda",
+          detail_model: "civic",
+          detail_body_type: "body.coupe",
+          detail_vehicle_model_date: 2021,
+          detail_mileage_unit: "KM",
+          detail_mileage_value: 12000,
+          detail_offer_price: 85000,
+          detail_name: "Honda Civic 2021",
+          detail_item_url: "https://example.com/civic",
+          created_at_iso: "2024-04-16T00:00:00Z",
+          city: "dubai",
+        }
+      ];
+
+      const data = url.includes("primary") ? primaryPayload : secondaryPayload;
+      return new Response(JSON.stringify(data), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("loads configured feeds and surfaces source summaries", async () => {
+    render(
+      <MemoryRouter initialEntries={["/admin"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Data Sources Console/i })).toBeInTheDocument();
+    });
+
+    const primaryRow = await screen.findByText("Primary feed");
+    expect(primaryRow).toBeInTheDocument();
+
+    const secondaryRowLabel = await screen.findByText("Secondary feed");
+    expect(secondaryRowLabel).toBeInTheDocument();
+
+    const secondaryRow = secondaryRowLabel.closest("tr");
+    expect(secondaryRow).not.toBeNull();
+    if (!secondaryRow) throw new Error("Secondary row not found");
+
+    expect(within(secondaryRow).getByText(/Raw: 1/)).toBeInTheDocument();
+    expect(within(secondaryRow).getByText(/ago/)).toBeInTheDocument();
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Flippers from "./pages/Flippers.jsx";
 import Analytics from "./pages/Analytics.jsx";
 import ReportBuilder from "./pages/ReportBuilder.jsx";
 import Admin from "./pages/Admin.jsx";
+import { normalizeExternalRow } from "./data/normalization.js";
 import {
   num,
   normalizeTimestamp,
@@ -81,57 +82,6 @@ const describeDateFilter = (filter, customWeeks) => {
     default:
       return { label: "All dates", cutoffMs: null, days: null };
   }
-};
-
-const cleanLabel = (value) => {
-  if (typeof value !== "string") return value ?? "";
-  const base = value.includes(".") ? value.split(".").pop() : value;
-  const spaced = base.replace(/[_-]+/g, " ").trim();
-  if (!spaced) return "";
-  return spaced
-    .split(/\s+/)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-};
-
-const normalizeCarswitchRow = (row) => {
-  if (!row || typeof row !== "object") return null;
-
-  const mileageUnit = typeof row.detail_mileage_unit === "string" ? row.detail_mileage_unit.toLowerCase() : "";
-  const kilometers = mileageUnit.startsWith("km") ? row.detail_mileage_value : null;
-  const createdAt = row.created_at || row.created_at_iso || row.createdAt;
-  const make = cleanLabel(row.make || row.detail_make);
-  const model = cleanLabel(row.model || row.detail_model);
-  const bodyType = (() => {
-    if (typeof row.detail_body_type !== "string") return cleanLabel(row.detail_body_type);
-    const base = row.detail_body_type.split(".").pop();
-    const label = cleanLabel(base);
-    return label.length <= 4 ? label.toUpperCase() : label;
-  })();
-
-  return {
-    ...row,
-    price: row.price ?? row.detail_offer_price ?? row.price_total,
-    details_make: make,
-    details_model: model,
-    details_year: row.detail_vehicle_model_date || row.year,
-    details_transmission: row.detail_vehicle_transmission || row.transmission,
-    details_body_type: bodyType,
-    details_drive_wheel_configuration: row.detail_drive_wheel_configuration || row.drive_configuration,
-    details_kilometers: kilometers ?? row.detail_mileage_value,
-    details_mileage_unit: row.detail_mileage_unit || row.mileage_unit || "km",
-    details_color: cleanLabel(row.detail_color || row.color),
-    details_regional_specs: row.regionalSpecs ? row.regionalSpecs.toUpperCase() : row.details_regional_specs,
-    details_seller_type: cleanLabel(row.listingType || row.details_seller_type),
-    url: row.detail_url || row.detail_item_url || row.url,
-    permalink: row.detail_item_url || row.permalink,
-    title_en: row.detail_name || row.title_en,
-    created_at: createdAt,
-    created_at_iso: row.created_at_iso || createdAt,
-    city_inferred: cleanLabel(row.city || row.city_inferred),
-    area_inferred: cleanLabel(row.area || row.area_inferred),
-    source: row.source || "crswtch",
-  };
 };
 
 export default function App() {
@@ -220,7 +170,7 @@ export default function App() {
     (async () => {
       try {
         const primaryUrls = resolveSourceUrls(import.meta.env.VITE_R2_JSON_URL, "__R2_JSON_URL__");
-        const carswitchUrls = resolveSourceUrls(import.meta.env.VITE_CRSWTCH_JSON_URL, "__CRSWTCH_JSON_URL__");
+        const secondaryUrls = resolveSourceUrls(import.meta.env.VITE_SECONDARY_JSON_URL, "__SECONDARY_JSON_URL__");
 
         if (!primaryUrls.length) {
           throw new Error("R2 JSON URL not set. Set VITE_R2_JSON_URL or window.__R2_JSON_URL__.");
@@ -256,11 +206,11 @@ export default function App() {
             normalize: (row) => ({ ...row, source: row?.source || "primary" })
           },
           {
-            key: "carswitch",
-            label: "CarSwitch",
-            urls: carswitchUrls,
+            key: "secondary",
+            label: "Secondary feed",
+            urls: secondaryUrls,
             optional: true,
-            normalize: (row) => normalizeCarswitchRow({ ...row, source: row?.source || "carswitch" })
+            normalize: (row) => normalizeExternalRow({ ...row, source: row?.source || "secondary" })
           }
         ];
 
@@ -325,9 +275,9 @@ export default function App() {
         });
 
         // Compute market averages for the last 3 months by (brand,model,year)
-        const now = Date.now();
+        const pricingNow = Date.now();
         const threeMonthsMs = 90 * 24 * 60 * 60 * 1000; // approx 3 months
-        const cutoff = now - threeMonthsMs;
+        const cutoff = pricingNow - threeMonthsMs;
 
         // Build segment aggregates
         const segMap = new Map(); // key => prices array
@@ -383,7 +333,7 @@ export default function App() {
 
         setData(rows);
 
-        const now = Date.now();
+        const summaryNow = Date.now();
         const summaryMap = new Map();
         for (const source of fetchedSources) {
           if (!summaryMap.has(source.key)) {
@@ -443,7 +393,7 @@ export default function App() {
             averagePrice: Number.isFinite(average) ? average : null,
             effectiveSample: count,
             removedOutliers: removed,
-            freshnessLabel: Number.isFinite(meta.latestMs) ? formatRelativeTime(meta.latestMs, now) : "No timestamp",
+            freshnessLabel: Number.isFinite(meta.latestMs) ? formatRelativeTime(meta.latestMs, summaryNow) : "No timestamp",
             coverageDays: Number.isFinite(rangeMs) ? Math.max(0, Math.round(rangeMs / (24 * 60 * 60 * 1000))) : null
           };
         });

--- a/src/data/normalization.js
+++ b/src/data/normalization.js
@@ -1,0 +1,50 @@
+export const cleanLabel = (value) => {
+  if (typeof value !== "string") return value ?? "";
+  const base = value.includes(".") ? value.split(".").pop() : value;
+  const spaced = base.replace(/[_-]+/g, " ").trim();
+  if (!spaced) return "";
+  return spaced
+    .split(/\s+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+};
+
+export const normalizeExternalRow = (row) => {
+  if (!row || typeof row !== "object") return null;
+
+  const mileageUnit = typeof row.detail_mileage_unit === "string" ? row.detail_mileage_unit.toLowerCase() : "";
+  const kilometers = mileageUnit.startsWith("km") ? row.detail_mileage_value : null;
+  const createdAt = row.created_at || row.created_at_iso || row.createdAt;
+  const make = cleanLabel(row.make || row.detail_make);
+  const model = cleanLabel(row.model || row.detail_model);
+  const bodyType = (() => {
+    if (typeof row.detail_body_type !== "string") return cleanLabel(row.detail_body_type);
+    const base = row.detail_body_type.split(".").pop();
+    const label = cleanLabel(base);
+    return label.length <= 4 ? label.toUpperCase() : label;
+  })();
+
+  return {
+    ...row,
+    price: row.price ?? row.detail_offer_price ?? row.price_total,
+    details_make: make,
+    details_model: model,
+    details_year: row.detail_vehicle_model_date || row.year,
+    details_transmission: row.detail_vehicle_transmission || row.transmission,
+    details_body_type: bodyType,
+    details_drive_wheel_configuration: row.detail_drive_wheel_configuration || row.drive_configuration,
+    details_kilometers: kilometers ?? row.detail_mileage_value,
+    details_mileage_unit: row.detail_mileage_unit || row.mileage_unit || "km",
+    details_color: cleanLabel(row.detail_color || row.color),
+    details_regional_specs: row.regionalSpecs ? row.regionalSpecs.toUpperCase() : row.details_regional_specs,
+    details_seller_type: cleanLabel(row.listingType || row.details_seller_type),
+    url: row.detail_url || row.detail_item_url || row.url,
+    permalink: row.detail_item_url || row.permalink,
+    title_en: row.detail_name || row.title_en,
+    created_at: createdAt,
+    created_at_iso: row.created_at_iso || createdAt,
+    city_inferred: cleanLabel(row.city || row.city_inferred),
+    area_inferred: cleanLabel(row.area || row.area_inferred),
+    source: row.source || "secondary",
+  };
+};

--- a/src/data/normalization.test.js
+++ b/src/data/normalization.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { cleanLabel, normalizeExternalRow } from "./normalization.js";
+
+describe("cleanLabel", () => {
+  it("capitalizes and de-hyphenates labels", () => {
+    expect(cleanLabel("mid-size_sedan")).toBe("Mid Size Sedan");
+  });
+
+  it("returns empty string for falsy input", () => {
+    expect(cleanLabel(null)).toBe("");
+  });
+});
+
+describe("normalizeExternalRow", () => {
+  it("maps external feed fields into dashboard schema", () => {
+    const normalized = normalizeExternalRow({
+      detail_make: "toyota",
+      detail_model: "corolla",
+      detail_body_type: "body.suv",
+      detail_vehicle_model_date: 2022,
+      detail_mileage_unit: "KM",
+      detail_mileage_value: 15000,
+      detail_offer_price: 55000,
+      regionalSpecs: "gcc",
+      listingType: "dealer",
+      detail_item_url: "https://example.com/car/123",
+      detail_name: "Toyota Corolla",
+      created_at_iso: "2024-01-01T00:00:00Z",
+      city: "abu_dhabi",
+    });
+
+    expect(normalized.details_make).toBe("Toyota");
+    expect(normalized.details_model).toBe("Corolla");
+    expect(normalized.details_body_type).toBe("SUV");
+    expect(normalized.details_mileage_unit).toBe("KM");
+    expect(normalized.details_kilometers).toBe(15000);
+    expect(normalized.price).toBe(55000);
+    expect(normalized.details_regional_specs).toBe("GCC");
+    expect(normalized.details_seller_type).toBe("Dealer");
+    expect(normalized.url).toBe("https://example.com/car/123");
+    expect(normalized.title_en).toBe("Toyota Corolla");
+    expect(normalized.city_inferred).toBe("Abu Dhabi");
+    expect(normalized.source).toBe("secondary");
+  });
+
+  it("returns null for invalid rows", () => {
+    expect(normalizeExternalRow(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the deprecated CarSwitch-specific feed handling with a generic secondary feed normalization helper
- update App.jsx to use the new helper, avoid duplicate `Date.now()` declarations, and rename the optional feed configuration keys
- refresh the README guidance and add focused unit and integration tests covering the secondary feed pipeline

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4d3d8ae4c833288c9cb0e1fa7a660