### PR TITLE
Fix admin source deduplication for secondary feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Secondary feeds exposed through `VITE_SECONDARY_JSON_URL` may expose listings us
 - **Feed visibility**: Quickly inspect how many listings arrived per feed and when they were last refreshed
 - **Freshness monitoring**: Human-readable freshness labels and ISO timestamps highlight stale sources immediately
 - **Quality guardrails**: Trimmed averages surface the effective sample size and how many outliers were excluded from pricing calculations
+- **Grouped vendors**: Each configured feed consolidates the vendor `source` labels it ingested (for example, "CSWITCH"), so secondary feeds no longer appear as fragmented duplicates.
 
 ## 🏗️ Architecture
 

--- a/src/App.integration.test.jsx
+++ b/src/App.integration.test.jsx
@@ -24,6 +24,7 @@ describe("App integration", () => {
           details_year: 2020,
           created_at_iso: "2024-04-15T00:00:00Z",
           created_at_epoch_ms: new Date("2024-04-15T00:00:00Z").getTime(),
+          source: "CSWITCH",
         }
       ];
 
@@ -53,8 +54,12 @@ describe("App integration", () => {
       expect(screen.getByRole("heading", { name: /Data Sources Console/i })).toBeInTheDocument();
     });
 
-    const primaryRow = await screen.findByText("Primary feed");
-    expect(primaryRow).toBeInTheDocument();
+    const primaryRowLabel = await screen.findByText("Primary feed");
+    expect(primaryRowLabel).toBeInTheDocument();
+
+    const table = screen.getByRole("table", { name: /Data source overview/i });
+    const rows = within(table).getAllByRole("row");
+    expect(rows).toHaveLength(3); // header + two data rows
 
     const secondaryRowLabel = await screen.findByText("Secondary feed");
     expect(secondaryRowLabel).toBeInTheDocument();
@@ -65,5 +70,12 @@ describe("App integration", () => {
 
     expect(within(secondaryRow).getByText(/Raw: 1/)).toBeInTheDocument();
     expect(within(secondaryRow).getByText(/ago/)).toBeInTheDocument();
+
+    const primaryRow = primaryRowLabel.closest("tr");
+    expect(primaryRow).not.toBeNull();
+    if (!primaryRow) throw new Error("Primary row not found");
+
+    expect(within(primaryRow).getByText("CSWITCH")).toBeInTheDocument();
+    expect(screen.queryByRole("row", { name: /^CSWITCH/i })).toBeNull();
   });
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -248,7 +248,11 @@ export default function App() {
               rawCount += arrayPayload.length;
               arrayPayload.forEach((item) => {
                 const normalized = config.normalize ? config.normalize(item) : item;
-                if (normalized) rows.push(normalized);
+                if (!normalized) return;
+                if (normalized && typeof normalized === "object") {
+                  normalized._sourceKey = config.key;
+                }
+                rows.push(normalized);
               });
             });
 
@@ -362,26 +366,47 @@ export default function App() {
               latestMs: null,
               earliestMs: null,
               prices: [],
-              rawCount: source.rawCount || 0
+              rawCount: source.rawCount || 0,
+              datasetSources: new Set()
             });
           }
         }
 
-        for (const d of rows) {
-          const key = d.source || "primary";
+        const ensureSummaryEntry = (key, fallbackLabel = key) => {
           if (!summaryMap.has(key)) {
             summaryMap.set(key, {
               key,
-              label: key,
+              label: fallbackLabel,
               urls: [],
               listingCount: 0,
               latestMs: null,
               earliestMs: null,
               prices: [],
-              rawCount: 0
+              rawCount: 0,
+              datasetSources: new Set()
             });
           }
-          const meta = summaryMap.get(key);
+          return summaryMap.get(key);
+        };
+
+        for (const d of rows) {
+          const sourceKey = d._sourceKey && summaryMap.has(d._sourceKey)
+            ? d._sourceKey
+            : summaryMap.has(d.source)
+              ? d.source
+              : "primary";
+
+          const meta = ensureSummaryEntry(sourceKey, sourceKey);
+          if (typeof d.source === "string") {
+            const trimmedLabel = d.source.trim();
+            if (trimmedLabel) {
+              const normalizedLabel = trimmedLabel.toLowerCase();
+              const normalizedKey = String(sourceKey || "").toLowerCase();
+              if (normalizedLabel !== normalizedKey) {
+                meta.datasetSources.add(trimmedLabel);
+              }
+            }
+          }
           meta.listingCount += 1;
           if (Number.isFinite(d.created_at_epoch_ms)) {
             meta.latestMs = meta.latestMs == null ? d.created_at_epoch_ms : Math.max(meta.latestMs, d.created_at_epoch_ms);
@@ -410,6 +435,7 @@ export default function App() {
             averagePrice: Number.isFinite(average) ? average : null,
             effectiveSample: count,
             removedOutliers: removed,
+            datasetSourceLabels: Array.from(meta.datasetSources).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" })),
             freshnessLabel: Number.isFinite(meta.latestMs) ? formatRelativeTime(meta.latestMs, summaryNow) : "No timestamp",
             coverageDays: Number.isFinite(rangeMs) ? Math.max(0, Math.round(rangeMs / (24 * 60 * 60 * 1000))) : null
           };

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -83,7 +83,19 @@ export default function Admin({ data = [], sources = [] }) {
                 <tbody>
                   {sources.map((src) => (
                     <tr key={src.key}>
-                      <th scope="row">{esc(src.label || src.key)}</th>
+                      <th scope="row">
+                        {esc(src.label || src.key)}
+                        {src.datasetSourceLabels && src.datasetSourceLabels.length > 0 && (
+                          <div className="text-muted small">
+                            {src.datasetSourceLabels.map((label, index) => (
+                              <React.Fragment key={`${src.key}-${label}-${index}`}>
+                                {index > 0 ? ", " : ""}
+                                {esc(label)}
+                              </React.Fragment>
+                            ))}
+                          </div>
+                        )}
+                      </th>
                       <td>
                         <div className="fw-semibold">{src.listingCount.toLocaleString()}</div>
                         <div className="text-muted small">


### PR DESCRIPTION
## Summary
- tag ingested rows with their configured feed and consolidate admin summaries
- expose vendor source labels beneath each feed in the Admin console
- extend integration coverage and documentation to cover the deduplicated secondary feed handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f512decbb883328d270fb24bd94bb6